### PR TITLE
Add stub-based arginfo generation using gen_stub.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ dist/php-em.wasm
 
 # VS Code settings (optional)
 .vscode/
+
+vendor/
+composer.lock
+PHP-Parser-*/

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -62,4 +62,13 @@ $(ORT_CUDA_LIBRARY): $(ORT_CUDA_OBJECTS)
 $(ORT_CUDA_OBJDIR)/%.o: $(ORT_CUDA_OBJDIR)/%.cu
 	$(NVCC) $(ORT_CUDA_CFLAGS) -c $< -o $@
 
-.PHONY: ort-cuda-kernels ort-test-coverage ort-test-coverage-lcov ort-test-coverage-html ort-test-parallel ort-test-parallel-valgrind
+################################################################################
+# Stubs Generation
+################################################################################
+ort-stubs:
+	php $(top_srcdir)/gen_stub.php $(top_srcdir)/ort.stub.php
+
+ort-stubs-force:
+	php $(top_srcdir)/gen_stub.php -f $(top_srcdir)/ort.stub.php
+
+.PHONY: ort-cuda-kernels ort-test-coverage ort-test-coverage-lcov ort-test-coverage-html ort-test-parallel ort-test-parallel-valgrind ort-stubs ort-stubs-force

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
           "needs-value": false
         }
     ]
+  },
+  "require-dev": {
+    "nikic/php-parser": "^5.7"
   }
 }

--- a/gen_stub.php
+++ b/gen_stub.php
@@ -1,0 +1,6640 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Comment\Doc as DocComment;
+use PhpParser\ConstExprEvaluator;
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PhpParser\PrettyPrinter\Standard;
+use PhpParser\PrettyPrinterAbstract;
+
+error_reporting(E_ALL);
+ini_set("precision", "-1");
+
+const PHP_70_VERSION_ID = 70000;
+const PHP_80_VERSION_ID = 80000;
+const PHP_81_VERSION_ID = 80100;
+const PHP_82_VERSION_ID = 80200;
+const PHP_83_VERSION_ID = 80300;
+const PHP_84_VERSION_ID = 80400;
+const PHP_85_VERSION_ID = 80500;
+const ALL_PHP_VERSION_IDS = [
+    PHP_70_VERSION_ID,
+    PHP_80_VERSION_ID,
+    PHP_81_VERSION_ID,
+    PHP_82_VERSION_ID,
+    PHP_83_VERSION_ID,
+    PHP_84_VERSION_ID,
+    PHP_85_VERSION_ID,
+];
+
+// file_put_contents() but with a success message printed after saving
+function reportFilePutContents(string $filename, string $content): void
+{
+    if (file_put_contents($filename, $content)) {
+        echo "Saved $filename\n";
+    }
+}
+
+/**
+ * @return FileInfo[]
+ */
+function processDirectory(string $dir, Context $context): array
+{
+    $pathNames = [];
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+    foreach ($it as $file) {
+        $pathName = $file->getPathName();
+        if (substr($pathName, -9) === '.stub.php') {
+            $pathNames[] = $pathName;
+        }
+    }
+
+    // Make sure stub files are processed in a predictable, system-independent order.
+    sort($pathNames);
+
+    $fileInfos = [];
+    foreach ($pathNames as $pathName) {
+        $fileInfo = processStubFile($pathName, $context);
+        if ($fileInfo) {
+            $fileInfos[] = $fileInfo;
+        }
+    }
+    return $fileInfos;
+}
+
+function processStubFile(string $stubFile, Context $context, bool $includeOnly = false): ?FileInfo
+{
+    try {
+        if (!file_exists($stubFile)) {
+            throw new Exception("File $stubFile does not exist");
+        }
+
+        if (!$includeOnly) {
+            $stubFilenameWithoutExtension = str_replace(".stub.php", "", $stubFile);
+            $arginfoFile = "{$stubFilenameWithoutExtension}_arginfo.h";
+            $legacyFile = "{$stubFilenameWithoutExtension}_legacy_arginfo.h";
+
+            $stubCode = file_get_contents($stubFile);
+            $stubHash = sha1(str_replace("\r\n", "\n", $stubCode));
+            $oldStubHash = extractStubHash($arginfoFile);
+            if ($stubHash === $oldStubHash && !$context->forceParse) {
+                /* Stub file did not change, do not regenerate. */
+                return null;
+            }
+        }
+
+        if (!$fileInfo = $context->parsedFiles[$stubFile] ?? null) {
+            initPhpParser();
+            $stubContent = $stubCode ?? file_get_contents($stubFile);
+            $fileInfo = FileInfo::parseStubFile($stubContent);
+            $context->parsedFiles[$stubFile] = $fileInfo;
+
+            foreach ($fileInfo->dependencies as $dependency) {
+                // TODO add header search path for extensions?
+                $prefixes = [dirname($stubFile) . "/", dirname(__DIR__) . "/"];
+                foreach ($prefixes as $prefix) {
+                    $depFile = $prefix . $dependency;
+                    if (file_exists($depFile)) {
+                        break;
+                    }
+                    $depFile = null;
+                }
+                if (!$depFile) {
+                    throw new Exception("File $stubFile includes a file $dependency which does not exist");
+                }
+                processStubFile($depFile, $context, true);
+            }
+
+            $constInfos = $fileInfo->getAllConstInfos();
+            $context->allConstInfos = array_merge($context->allConstInfos, $constInfos);
+        }
+
+        if ($includeOnly) {
+            return $fileInfo;
+        }
+
+        $arginfoCode = generateArgInfoCode(
+            basename($stubFilenameWithoutExtension),
+            $fileInfo,
+            $context->allConstInfos,
+            $stubHash
+        );
+        if ($context->forceRegeneration || $stubHash !== $oldStubHash) {
+            reportFilePutContents($arginfoFile, $arginfoCode);
+        }
+
+        if ($fileInfo->shouldGenerateLegacyArginfo()) {
+            $legacyFileInfo = $fileInfo->getLegacyVersion();
+
+            $arginfoCode = generateArgInfoCode(
+                basename($stubFilenameWithoutExtension),
+                $legacyFileInfo,
+                $context->allConstInfos,
+                $stubHash
+            );
+            if ($context->forceRegeneration || $stubHash !== $oldStubHash) {
+                reportFilePutContents($legacyFile, $arginfoCode);
+            }
+        }
+
+        return $fileInfo;
+    } catch (Exception $e) {
+        echo "In $stubFile:\n{$e->getMessage()}\n";
+        exit(1);
+    }
+}
+
+function extractStubHash(string $arginfoFile): ?string
+{
+    if (!file_exists($arginfoFile)) {
+        return null;
+    }
+
+    $arginfoCode = file_get_contents($arginfoFile);
+    if (!preg_match('/\* Stub hash: ([0-9a-f]+) \*/', $arginfoCode, $matches)) {
+        return null;
+    }
+
+    return $matches[1];
+}
+
+class Context
+{
+    public bool $forceParse = false;
+    public bool $forceRegeneration = false;
+    /** @var array<string, ConstInfo> */
+    public array $allConstInfos = [];
+    /** @var FileInfo[] */
+    public array $parsedFiles = [];
+}
+
+class ArrayType extends SimpleType
+{
+    private /* readonly */ Type $keyType;
+    private /* readonly */ Type $valueType;
+
+    public static function createGenericArray(): self
+    {
+        return new ArrayType(Type::fromString("int|string"), Type::fromString("mixed|ref"));
+    }
+
+    public function __construct(Type $keyType, Type $valueType)
+    {
+        parent::__construct("array", true);
+
+        $this->keyType = $keyType;
+        $this->valueType = $valueType;
+    }
+
+    public function toOptimizerTypeMask(): string
+    {
+        $typeMasks = [
+            parent::toOptimizerTypeMask(),
+            $this->keyType->toOptimizerTypeMaskForArrayKey(),
+            $this->valueType->toOptimizerTypeMaskForArrayValue(),
+        ];
+
+        return implode("|", $typeMasks);
+    }
+
+    public function equals(SimpleType $other): bool
+    {
+        if (!parent::equals($other)) {
+            return false;
+        }
+
+        assert(get_class($other) === self::class);
+
+        return Type::equals($this->keyType, $other->keyType) &&
+            Type::equals($this->valueType, $other->valueType);
+    }
+}
+
+class SimpleType
+{
+    public /* readonly */ string $name;
+    public /* readonly */ bool $isBuiltin;
+
+    public static function fromNode(Node $node): SimpleType
+    {
+        if ($node instanceof Node\Name) {
+            if ($node->toLowerString() === 'static') {
+                // PHP internally considers "static" a builtin type.
+                return new SimpleType($node->toLowerString(), true);
+            }
+
+            if ($node->toLowerString() === 'self') {
+                throw new Exception('The exact class name must be used instead of "self"');
+            }
+
+            assert($node->isFullyQualified());
+            return new SimpleType($node->toString(), false);
+        }
+
+        if ($node instanceof Node\Identifier) {
+            if ($node->toLowerString() === 'array') {
+                return ArrayType::createGenericArray();
+            }
+
+            return new SimpleType($node->toLowerString(), true);
+        }
+
+        throw new Exception("Unexpected node type");
+    }
+
+    public static function fromString(string $typeString): SimpleType
+    {
+        switch (strtolower($typeString)) {
+            case "void":
+            case "null":
+            case "false":
+            case "true":
+            case "bool":
+            case "int":
+            case "float":
+            case "string":
+            case "callable":
+            case "object":
+            case "resource":
+            case "mixed":
+            case "static":
+            case "never":
+            case "ref":
+                return new SimpleType(strtolower($typeString), true);
+            case "array":
+                return ArrayType::createGenericArray();
+            case "self":
+                throw new Exception('The exact class name must be used instead of "self"');
+            case "iterable":
+                throw new Exception('This should not happen');
+        }
+
+        $matches = [];
+        $isArray = preg_match("/(.*)\s*\[\s*\]/", $typeString, $matches);
+        if ($isArray) {
+            return new ArrayType(Type::fromString("int"), Type::fromString($matches[1]));
+        }
+
+        $matches = [];
+        $isArray = preg_match("/array\s*<\s*([A-Za-z0-9_|-]+)?(\s*,\s*)?([A-Za-z0-9_|-]+)?\s*>/i", $typeString, $matches);
+        if ($isArray) {
+            if (empty($matches[1]) || empty($matches[3])) {
+                throw new Exception("array<> type hint must have both a key and a value");
+            }
+
+            return new ArrayType(Type::fromString($matches[1]), Type::fromString($matches[3]));
+        }
+
+        return new SimpleType($typeString, false);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function fromValue($value): SimpleType
+    {
+        switch (gettype($value)) {
+            case "NULL":
+                return SimpleType::null();
+            case "boolean":
+                return new SimpleType("bool", true);
+            case "integer":
+                return new SimpleType("int", true);
+            case "double":
+                return new SimpleType("float", true);
+            case "string":
+                return new SimpleType("string", true);
+            case "array":
+                return new SimpleType("array", true);
+            case "object":
+                return new SimpleType("object", true);
+            default:
+                throw new Exception("Type \"" . gettype($value) . "\" cannot be inferred based on value");
+        }
+    }
+
+    public static function null(): SimpleType
+    {
+        return new SimpleType("null", true);
+    }
+
+    protected function __construct(string $name, bool $isBuiltin)
+    {
+        $this->name = $name;
+        $this->isBuiltin = $isBuiltin;
+    }
+
+    public function isScalar(): bool
+    {
+        return $this->isBuiltin && in_array($this->name, ["null", "false", "true", "bool", "int", "float"], true);
+    }
+
+    public function isNull(): bool
+    {
+        return $this->isBuiltin && $this->name === 'null';
+    }
+
+    public function isBool(): bool
+    {
+        return $this->isBuiltin && $this->name === 'bool';
+    }
+
+    public function isInt(): bool
+    {
+        return $this->isBuiltin && $this->name === 'int';
+    }
+
+    public function isFloat(): bool
+    {
+        return $this->isBuiltin && $this->name === 'float';
+    }
+
+    public function isString(): bool
+    {
+        return $this->isBuiltin && $this->name === 'string';
+    }
+
+    public function isArray(): bool
+    {
+        return $this->isBuiltin && $this->name === 'array';
+    }
+
+    public function isMixed(): bool
+    {
+        return $this->isBuiltin && $this->name === 'mixed';
+    }
+
+    private function toTypeInfo(): array
+    {
+        assert($this->isBuiltin);
+
+        switch ($this->name) {
+            case "null":
+                return ["IS_NULL", "MAY_BE_NULL"];
+            case "false":
+                return ["IS_FALSE", "MAY_BE_FALSE"];
+            case "true":
+                return ["IS_TRUE", "MAY_BE_TRUE"];
+            case "bool":
+                return ["_IS_BOOL", "MAY_BE_BOOL"];
+            case "int":
+                return ["IS_LONG", "MAY_BE_LONG"];
+            case "float":
+                return ["IS_DOUBLE", "MAY_BE_DOUBLE"];
+            case "string":
+                return ["IS_STRING", "MAY_BE_STRING"];
+            case "array":
+                return ["IS_ARRAY", "MAY_BE_ARRAY"];
+            case "object":
+                return ["IS_OBJECT", "MAY_BE_OBJECT"];
+            case "callable":
+                return ["IS_CALLABLE", "MAY_BE_CALLABLE"];
+            case "mixed":
+                return ["IS_MIXED", "MAY_BE_ANY"];
+            case "void":
+                return ["IS_VOID", "MAY_BE_VOID"];
+            case "static":
+                return ["IS_STATIC", "MAY_BE_STATIC"];
+            case "never":
+                return ["IS_NEVER", "MAY_BE_NEVER"];
+            default:
+                throw new Exception("Not implemented: $this->name");
+        }
+    }
+
+    public function toTypeCode(): string
+    {
+        return $this->toTypeInfo()[0];
+    }
+
+    public function toTypeMask(): string
+    {
+        return $this->toTypeInfo()[1];
+    }
+
+    public function toOptimizerTypeMaskForArrayKey(): string
+    {
+        assert($this->isBuiltin);
+
+        switch ($this->name) {
+            case "int":
+                return "MAY_BE_ARRAY_KEY_LONG";
+            case "string":
+                return "MAY_BE_ARRAY_KEY_STRING";
+            default:
+                throw new Exception("Type $this->name cannot be an array key");
+        }
+    }
+
+    public function toOptimizerTypeMaskForArrayValue(): string
+    {
+        if (!$this->isBuiltin) {
+            return "MAY_BE_ARRAY_OF_OBJECT";
+        }
+
+        switch ($this->name) {
+            case "null":
+                return "MAY_BE_ARRAY_OF_NULL";
+            case "false":
+                return "MAY_BE_ARRAY_OF_FALSE";
+            case "true":
+                return "MAY_BE_ARRAY_OF_TRUE";
+            case "bool":
+                return "MAY_BE_ARRAY_OF_FALSE|MAY_BE_ARRAY_OF_TRUE";
+            case "int":
+                return "MAY_BE_ARRAY_OF_LONG";
+            case "float":
+                return "MAY_BE_ARRAY_OF_DOUBLE";
+            case "string":
+                return "MAY_BE_ARRAY_OF_STRING";
+            case "array":
+                return "MAY_BE_ARRAY_OF_ARRAY";
+            case "object":
+                return "MAY_BE_ARRAY_OF_OBJECT";
+            case "resource":
+                return "MAY_BE_ARRAY_OF_RESOURCE";
+            case "mixed":
+                return "MAY_BE_ARRAY_OF_ANY";
+            case "ref":
+                return "MAY_BE_ARRAY_OF_REF";
+            default:
+                throw new Exception("Type $this->name cannot be an array value");
+        }
+    }
+
+    public function toOptimizerTypeMask(): string
+    {
+        if (!$this->isBuiltin) {
+            return "MAY_BE_OBJECT";
+        }
+
+        switch ($this->name) {
+            case "resource":
+                return "MAY_BE_RESOURCE";
+            case "callable":
+                return "MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_OBJECT|MAY_BE_OBJECT";
+            case "iterable":
+                return "MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY|MAY_BE_OBJECT";
+            case "mixed":
+                return "MAY_BE_ANY|MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY";
+        }
+
+        return $this->toTypeMask();
+    }
+
+    public function toEscapedName(): string
+    {
+        // Escape backslashes, and also encode \u, \U, and \N to avoid compilation errors in generated macros
+        return str_replace(
+            ['\\', '\\u', '\\U', '\\N'],
+            ['\\\\', '\\\\165', '\\\\125', '\\\\116'],
+            $this->name
+        );
+    }
+
+    public function toVarEscapedName(): string
+    {
+        return str_replace('\\', '_', $this->name);
+    }
+
+    public function equals(SimpleType $other): bool
+    {
+        return $this->name === $other->name && $this->isBuiltin === $other->isBuiltin;
+    }
+}
+
+// Instances of Type are immutable and do not need to be cloned
+// when held by an object that is cloned
+class Type
+{
+    /** @var SimpleType[] */
+    public /* readonly */ array $types;
+    public /* readonly */ bool $isIntersection;
+
+    public static function fromNode(Node $node): Type
+    {
+        if ($node instanceof Node\UnionType || $node instanceof Node\IntersectionType) {
+            $nestedTypeObjects = array_map(['Type', 'fromNode'], $node->types);
+            $types = [];
+            foreach ($nestedTypeObjects as $typeObject) {
+                array_push($types, ...$typeObject->types);
+            }
+            return new Type($types, ($node instanceof Node\IntersectionType));
+        }
+
+        if ($node instanceof Node\NullableType) {
+            return new Type(
+                [
+                    ...Type::fromNode($node->type)->types,
+                    SimpleType::null(),
+                ],
+                false
+            );
+        }
+
+        if ($node instanceof Node\Identifier && $node->toLowerString() === "iterable") {
+            return new Type(
+                [
+                    SimpleType::fromString("Traversable"),
+                    ArrayType::createGenericArray(),
+                ],
+                false
+            );
+        }
+
+        return new Type([SimpleType::fromNode($node)], false);
+    }
+
+    public static function fromString(string $typeString): self
+    {
+        $typeString .= "|";
+        $simpleTypes = [];
+        $simpleTypeOffset = 0;
+        $inArray = false;
+        $isIntersection = false;
+
+        $typeStringLength = strlen($typeString);
+        for ($i = 0; $i < $typeStringLength; $i++) {
+            $char = $typeString[$i];
+
+            if ($char === "<") {
+                $inArray = true;
+                continue;
+            }
+
+            if ($char === ">") {
+                $inArray = false;
+                continue;
+            }
+
+            if ($inArray) {
+                continue;
+            }
+
+            if ($char === "|" || $char === "&") {
+                $isIntersection = ($char === "&");
+                $simpleTypeName = trim(substr($typeString, $simpleTypeOffset, $i - $simpleTypeOffset));
+
+                $simpleTypes[] = SimpleType::fromString($simpleTypeName);
+
+                $simpleTypeOffset = $i + 1;
+            }
+        }
+
+        return new Type($simpleTypes, $isIntersection);
+    }
+
+    /**
+     * @param SimpleType[] $types
+     */
+    private function __construct(array $types, bool $isIntersection)
+    {
+        $this->types = $types;
+        $this->isIntersection = $isIntersection;
+    }
+
+    public function isScalar(): bool
+    {
+        foreach ($this->types as $type) {
+            if (!$type->isScalar()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function isNullable(): bool
+    {
+        foreach ($this->types as $type) {
+            if ($type->isNull()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function tryToSimpleType(): ?SimpleType
+    {
+        $nonNullTypes = array_filter(
+            $this->types,
+            function (SimpleType $type) {
+                return !$type->isNull();
+            }
+        );
+        /* type has only null */
+        if (count($nonNullTypes) === 0) {
+            return $this->types[0];
+        }
+        if (count($nonNullTypes) === 1) {
+            return reset($nonNullTypes);
+        }
+        return null;
+    }
+
+    public function toArginfoType(): ArginfoType
+    {
+        $classTypes = [];
+        $builtinTypes = [];
+        foreach ($this->types as $type) {
+            if ($type->isBuiltin) {
+                $builtinTypes[] = $type;
+            } else {
+                $classTypes[] = $type;
+            }
+        }
+        return new ArginfoType($classTypes, $builtinTypes);
+    }
+
+    public function toOptimizerTypeMask(): string
+    {
+        $optimizerTypes = [];
+
+        foreach ($this->types as $type) {
+            // TODO Support for toOptimizerMask for intersection
+            $optimizerTypes[] = $type->toOptimizerTypeMask();
+        }
+
+        return implode("|", $optimizerTypes);
+    }
+
+    public function toOptimizerTypeMaskForArrayKey(): string
+    {
+        $typeMasks = [];
+
+        foreach ($this->types as $type) {
+            $typeMasks[] = $type->toOptimizerTypeMaskForArrayKey();
+        }
+
+        return implode("|", $typeMasks);
+    }
+
+    public function toOptimizerTypeMaskForArrayValue(): string
+    {
+        $typeMasks = [];
+
+        foreach ($this->types as $type) {
+            $typeMasks[] = $type->toOptimizerTypeMaskForArrayValue();
+        }
+
+        return implode("|", $typeMasks);
+    }
+
+    public function getTypeForDoc(DOMDocument $doc): DOMElement
+    {
+        if (count($this->types) > 1) {
+            $typeSort = $this->isIntersection ? "intersection" : "union";
+            $typeElement = $doc->createElement('type');
+            $typeElement->setAttribute("class", $typeSort);
+
+            foreach ($this->types as $type) {
+                $unionTypeElement = $doc->createElement('type', $type->name);
+                $typeElement->appendChild($unionTypeElement);
+            }
+        } else {
+            $type = $this->types[0];
+            $typeElement = $doc->createElement('type', $type->name);
+        }
+
+        return $typeElement;
+    }
+
+    public static function equals(?Type $a, ?Type $b): bool
+    {
+        if ($a === null || $b === null) {
+            return $a === $b;
+        }
+
+        if (count($a->types) !== count($b->types)) {
+            return false;
+        }
+
+        for ($i = 0; $i < count($a->types); $i++) {
+            if (!$a->types[$i]->equals($b->types[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function __toString()
+    {
+        $char = $this->isIntersection ? '&' : '|';
+        return implode(
+            $char,
+            array_map(
+                function ($type) {
+                    return $type->name;
+                },
+                $this->types
+            )
+        );
+    }
+}
+
+class ArginfoType
+{
+    /** @var SimpleType[] $classTypes */
+    public /* readonly */ array $classTypes;
+    /** @var SimpleType[] $builtinTypes */
+    private /* readonly */ array $builtinTypes;
+
+    /**
+     * @param SimpleType[] $classTypes
+     * @param SimpleType[] $builtinTypes
+     */
+    public function __construct(array $classTypes, array $builtinTypes)
+    {
+        $this->classTypes = $classTypes;
+        $this->builtinTypes = $builtinTypes;
+    }
+
+    public function hasClassType(): bool
+    {
+        return !empty($this->classTypes);
+    }
+
+    public function toClassTypeString(): string
+    {
+        return implode('|', array_map(function (SimpleType $type) {
+            return $type->toEscapedName();
+        }, $this->classTypes));
+    }
+
+    public function toTypeMask(): string
+    {
+        if (empty($this->builtinTypes)) {
+            return '0';
+        }
+        return implode('|', array_map(function (SimpleType $type) {
+            return $type->toTypeMask();
+        }, $this->builtinTypes));
+    }
+}
+
+class ArgInfo
+{
+    public const SEND_BY_VAL = "0";
+    public const SEND_BY_REF = "1";
+    public const SEND_PREFER_REF = "ZEND_SEND_PREFER_REF";
+
+    public /* readonly */ string $name;
+    public /* readonly */ string $sendBy;
+    public /* readonly */ bool $isVariadic;
+    public ?Type $type;
+    private /* readonly */ ?Type $phpDocType;
+    public ?string $defaultValue;
+    /** @var AttributeInfo[] */
+    public array $attributes;
+
+    /**
+     * @param AttributeInfo[] $attributes
+     */
+    public function __construct(
+        string $name,
+        string $sendBy,
+        bool $isVariadic,
+        ?Type $type,
+        ?Type $phpDocType,
+        ?string $defaultValue,
+        array $attributes
+    ) {
+        $this->name = $name;
+        $this->sendBy = $sendBy;
+        $this->isVariadic = $isVariadic;
+        $this->type = $type;
+        $this->phpDocType = $phpDocType;
+        $this->defaultValue = $defaultValue;
+        $this->attributes = $attributes;
+    }
+
+    public function equals(ArgInfo $other): bool
+    {
+        return $this->name === $other->name
+            && $this->sendBy === $other->sendBy
+            && $this->isVariadic === $other->isVariadic
+            && Type::equals($this->type, $other->type)
+            && $this->defaultValue === $other->defaultValue;
+    }
+
+    public function getMethodSynopsisType(): Type
+    {
+        if ($this->type) {
+            return $this->type;
+        }
+
+        if ($this->phpDocType) {
+            return $this->phpDocType;
+        }
+
+        throw new Exception("A parameter must have a type");
+    }
+
+    public function hasProperDefaultValue(): bool
+    {
+        return $this->defaultValue !== null && $this->defaultValue !== "UNKNOWN";
+    }
+
+    private function getDefaultValueAsArginfoString(): string
+    {
+        if ($this->hasProperDefaultValue()) {
+            return '"' . addslashes($this->defaultValue) . '"';
+        }
+
+        return "NULL";
+    }
+
+    public function getDefaultValueAsMethodSynopsisString(): ?string
+    {
+        switch ($this->defaultValue) {
+            case 'UNKNOWN':
+                return null;
+            case 'false':
+            case 'true':
+            case 'null':
+                return "&{$this->defaultValue};";
+        }
+
+        return $this->defaultValue;
+    }
+
+    public function toZendInfo(): string
+    {
+        $argKind = $this->isVariadic ? "ARG_VARIADIC" : "ARG";
+        $argDefaultKind = $this->hasProperDefaultValue() ? "_WITH_DEFAULT_VALUE" : "";
+        $argType = $this->type;
+        if ($argType !== null) {
+            if (null !== $simpleArgType = $argType->tryToSimpleType()) {
+                if ($simpleArgType->isBuiltin) {
+                    return sprintf(
+                        "\tZEND_%s_TYPE_INFO%s(%s, %s, %s, %d%s)\n",
+                        $argKind,
+                        $argDefaultKind,
+                        $this->sendBy,
+                        $this->name,
+                        $simpleArgType->toTypeCode(),
+                        $argType->isNullable(),
+                        $this->hasProperDefaultValue() ? ", " . $this->getDefaultValueAsArginfoString() : ""
+                    );
+                }
+                return sprintf(
+                    "\tZEND_%s_OBJ_INFO%s(%s, %s, %s, %d%s)\n",
+                    $argKind,
+                    $argDefaultKind,
+                    $this->sendBy,
+                    $this->name,
+                    $simpleArgType->toEscapedName(),
+                    $argType->isNullable(),
+                    $this->hasProperDefaultValue() ? ", " . $this->getDefaultValueAsArginfoString() : ""
+                );
+            }
+            $arginfoType = $argType->toArginfoType();
+            if ($arginfoType->hasClassType()) {
+                return sprintf(
+                    "\tZEND_%s_OBJ_TYPE_MASK(%s, %s, %s, %s%s)\n",
+                    $argKind,
+                    $this->sendBy,
+                    $this->name,
+                    $arginfoType->toClassTypeString(),
+                    $arginfoType->toTypeMask(),
+                    !$this->isVariadic ? ", " . $this->getDefaultValueAsArginfoString() : ""
+                );
+            }
+            return sprintf(
+                "\tZEND_%s_TYPE_MASK(%s, %s, %s, %s)\n",
+                $argKind,
+                $this->sendBy,
+                $this->name,
+                $arginfoType->toTypeMask(),
+                $this->getDefaultValueAsArginfoString()
+            );
+        }
+        return sprintf(
+            "\tZEND_%s_INFO%s(%s, %s%s)\n",
+            $argKind,
+            $argDefaultKind,
+            $this->sendBy,
+            $this->name,
+            $this->hasProperDefaultValue() ? ", " . $this->getDefaultValueAsArginfoString() : ""
+        );
+    }
+}
+
+interface VariableLikeName
+{
+    public function __toString(): string;
+    public function getDeclarationName(): string;
+}
+
+abstract class AbstractConstName implements VariableLikeName
+{
+    public function isUnknown(): bool
+    {
+        return strtolower($this->__toString()) === "unknown";
+    }
+}
+
+class ConstName extends AbstractConstName
+{
+    private /* readonly */ string $const;
+
+    public function __construct(?Name $namespace, string $const)
+    {
+        if ($namespace && ($namespace = $namespace->slice(0, -1))) {
+            $const = $namespace->toString() . '\\' . $const;
+        }
+        $this->const = $const;
+    }
+
+    public function isUnknown(): bool
+    {
+        $name = $this->__toString();
+        if (($pos = strrpos($name, '\\')) !== false) {
+            $name = substr($name, $pos + 1);
+        }
+        return strtolower($name) === "unknown";
+    }
+
+    public function __toString(): string
+    {
+        return $this->const;
+    }
+
+    public function getDeclarationName(): string
+    {
+        return $this->name->toString();
+    }
+}
+
+class ClassConstName extends AbstractConstName
+{
+    public /* readonly */ Name $class;
+    private /* readonly */ string $const;
+
+    public function __construct(Name $class, string $const)
+    {
+        $this->class = $class;
+        $this->const = $const;
+    }
+
+    public function __toString(): string
+    {
+        return $this->class->toString() . "::" . $this->const;
+    }
+
+    public function getDeclarationName(): string
+    {
+        return $this->const;
+    }
+}
+
+class PropertyName implements VariableLikeName
+{
+    public /* readonly */ Name $class;
+    private /* readonly */ string $property;
+
+    public function __construct(Name $class, string $property)
+    {
+        $this->class = $class;
+        $this->property = $property;
+    }
+
+    public function __toString(): string
+    {
+        return $this->class->toString() . "::$" . $this->property;
+    }
+
+    public function getDeclarationName(): string
+    {
+        return $this->property;
+    }
+}
+
+interface FunctionOrMethodName
+{
+    public function getDeclaration(): string;
+    public function getArgInfoName(): string;
+    public function getMethodSynopsisFilename(): string;
+    public function getNameForAttributes(): string;
+    public function __toString(): string;
+    public function isConstructor(): bool;
+    public function isDestructor(): bool;
+}
+
+class FunctionName implements FunctionOrMethodName
+{
+    private /* readonly */ Name $name;
+
+    public function __construct(Name $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getNamespace(): ?string
+    {
+        if ($this->name->isQualified()) {
+            return $this->name->slice(0, -1)->toString();
+        }
+        return null;
+    }
+
+    public function getNonNamespacedName(): string
+    {
+        if ($this->name->isQualified()) {
+            throw new Exception("Namespaced name not supported here");
+        }
+        return $this->name->toString();
+    }
+
+    public function getDeclarationName(): string
+    {
+        return implode('_', $this->name->getParts());
+    }
+
+    public function getFunctionName(): string
+    {
+        return $this->name->getLast();
+    }
+
+    public function getDeclaration(): string
+    {
+        return "ZEND_FUNCTION({$this->getDeclarationName()});\n";
+    }
+
+    public function getArgInfoName(): string
+    {
+        $underscoreName = implode('_', $this->name->getParts());
+        return "arginfo_$underscoreName";
+    }
+
+    public function getFramelessFunctionInfosName(): string
+    {
+        $underscoreName = implode('_', $this->name->getParts());
+        return "frameless_function_infos_$underscoreName";
+    }
+
+    public function getMethodSynopsisFilename(): string
+    {
+        return 'functions/' . implode('/', str_replace('_', '-', $this->name->getParts()));
+    }
+
+    public function getNameForAttributes(): string
+    {
+        return strtolower($this->name->toString());
+    }
+
+    public function __toString(): string
+    {
+        return $this->name->toString();
+    }
+
+    public function isConstructor(): bool
+    {
+        return false;
+    }
+
+    public function isDestructor(): bool
+    {
+        return false;
+    }
+}
+
+class MethodName implements FunctionOrMethodName
+{
+    public /* readonly */ Name $className;
+    public /* readonly */ string $methodName;
+
+    public function __construct(Name $className, string $methodName)
+    {
+        $this->className = $className;
+        $this->methodName = $methodName;
+    }
+
+    public function getDeclarationClassName(): string
+    {
+        return implode('_', $this->className->getParts());
+    }
+
+    public function getDeclaration(): string
+    {
+        return "ZEND_METHOD({$this->getDeclarationClassName()}, $this->methodName);\n";
+    }
+
+    public function getArgInfoName(): string
+    {
+        return "arginfo_class_{$this->getDeclarationClassName()}_{$this->methodName}";
+    }
+
+    public function getMethodSynopsisFilename(): string
+    {
+        $parts = [...$this->className->getParts(), ltrim($this->methodName, '_')];
+        /* File paths are in lowercase */
+        return strtolower(implode('/', $parts));
+    }
+
+    public function getNameForAttributes(): string
+    {
+        return strtolower($this->methodName);
+    }
+
+    public function __toString(): string
+    {
+        return "$this->className::$this->methodName";
+    }
+
+    public function isConstructor(): bool
+    {
+        return $this->methodName === "__construct";
+    }
+
+    public function isDestructor(): bool
+    {
+        return $this->methodName === "__destruct";
+    }
+}
+
+class ReturnInfo
+{
+    public const REFCOUNT_0 = "0";
+    public const REFCOUNT_1 = "1";
+    public const REFCOUNT_N = "N";
+
+    public const REFCOUNTS_NONSCALAR = [
+        self::REFCOUNT_1,
+        self::REFCOUNT_N,
+    ];
+
+    private /* readonly */ bool $byRef;
+    // NOT readonly - gets removed when discarding info for older PHP versions
+    public ?Type $type;
+    public /* readonly */ ?Type $phpDocType;
+    public /* readonly */ bool $tentativeReturnType;
+    public /* readonly */ string $refcount;
+
+    public function __construct(bool $byRef, ?Type $type, ?Type $phpDocType, bool $tentativeReturnType, ?string $refcount)
+    {
+        $this->byRef = $byRef;
+        $this->type = $type;
+        $this->phpDocType = $phpDocType;
+        $this->tentativeReturnType = $tentativeReturnType;
+        $this->setRefcount($refcount);
+    }
+
+    public function equalsApartFromPhpDocAndRefcount(ReturnInfo $other): bool
+    {
+        return $this->byRef === $other->byRef
+            && Type::equals($this->type, $other->type)
+            && $this->tentativeReturnType === $other->tentativeReturnType;
+    }
+
+    public function getMethodSynopsisType(): ?Type
+    {
+        return $this->type ?? $this->phpDocType;
+    }
+
+    private function setRefcount(?string $refcount): void
+    {
+        $type = $this->phpDocType ?? $this->type;
+        $isScalarType = $type !== null && $type->isScalar();
+
+        if ($refcount === null) {
+            $this->refcount = $isScalarType ? self::REFCOUNT_0 : self::REFCOUNT_N;
+            return;
+        }
+
+        if ($isScalarType) {
+            throw new Exception(
+                "@refcount on functions returning scalar values is redundant and not permitted"
+            );
+        }
+
+        if (!in_array($refcount, ReturnInfo::REFCOUNTS_NONSCALAR, true)) {
+            throw new Exception("@refcount must have one of the following values: \"1\", \"N\", $refcount given");
+        }
+
+        $this->refcount = $refcount;
+    }
+
+    public function beginArgInfo(string $funcInfoName, int $minArgs, bool $php81MinimumCompatibility): string
+    {
+        $code = $this->beginArgInfoCompatible($funcInfoName, $minArgs);
+        if ($this->type !== null && $this->tentativeReturnType && !$php81MinimumCompatibility) {
+            $realCode = "#if (PHP_VERSION_ID >= " . PHP_81_VERSION_ID . ")\n";
+            $realCode .= $code;
+            $realCode .= sprintf(
+                "#else\nZEND_BEGIN_ARG_INFO_EX(%s, 0, %d, %d)\n#endif\n",
+                $funcInfoName,
+                $this->byRef,
+                $minArgs
+            );
+            return $realCode;
+        }
+        return $code;
+    }
+
+    /**
+     * Assumes PHP 8.1 compatibility, if that is not the case the caller is
+     * responsible for making the use of a tentative return type conditional
+     * based on the PHP version. Separate to allow using early returns
+     */
+    private function beginArgInfoCompatible(string $funcInfoName, int $minArgs): string
+    {
+        if ($this->type !== null) {
+            if (null !== $simpleReturnType = $this->type->tryToSimpleType()) {
+                if ($simpleReturnType->isBuiltin) {
+                    return sprintf(
+                        "%s(%s, %d, %d, %s, %d)\n",
+                        $this->tentativeReturnType ? "ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX" : "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX",
+                        $funcInfoName,
+                        $this->byRef,
+                        $minArgs,
+                        $simpleReturnType->toTypeCode(),
+                        $this->type->isNullable()
+                    );
+                }
+                return sprintf(
+                    "%s(%s, %d, %d, %s, %d)\n",
+                    $this->tentativeReturnType ? "ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX" : "ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX",
+                    $funcInfoName,
+                    $this->byRef,
+                    $minArgs,
+                    $simpleReturnType->toEscapedName(),
+                    $this->type->isNullable()
+                );
+            }
+            $arginfoType = $this->type->toArginfoType();
+            if ($arginfoType->hasClassType()) {
+                return sprintf(
+                    "%s(%s, %d, %d, %s, %s)\n",
+                    $this->tentativeReturnType ? "ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX" : "ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX",
+                    $funcInfoName,
+                    $this->byRef,
+                    $minArgs,
+                    $arginfoType->toClassTypeString(),
+                    $arginfoType->toTypeMask()
+                );
+            }
+            return sprintf(
+                "%s(%s, %d, %d, %s)\n",
+                $this->tentativeReturnType ? "ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX" : "ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX",
+                $funcInfoName,
+                $this->byRef,
+                $minArgs,
+                $arginfoType->toTypeMask()
+            );
+        }
+        return sprintf(
+            "ZEND_BEGIN_ARG_INFO_EX(%s, 0, %d, %d)\n",
+            $funcInfoName,
+            $this->byRef,
+            $minArgs
+        );
+    }
+}
+
+class VersionFlags
+{
+
+    /**
+     * Keys are the PHP versions, values are arrays of flags
+     */
+    private array $flagsByVersion;
+
+    public function __construct(array $baseFlags)
+    {
+        $this->flagsByVersion = [];
+        foreach (ALL_PHP_VERSION_IDS as $version) {
+            $this->flagsByVersion[$version] = $baseFlags;
+        }
+    }
+
+    public function addForVersionsAbove(string $flag, int $minimumVersionId): void
+    {
+        $write = false;
+
+        foreach (ALL_PHP_VERSION_IDS as $version) {
+            if ($version === $minimumVersionId || $write === true) {
+                $this->flagsByVersion[$version][] = $flag;
+                $write = true;
+            }
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        foreach (ALL_PHP_VERSION_IDS as $version) {
+            if ($this->flagsByVersion[$version] !== []) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function generateVersionDependentFlagCode(
+        string $codeTemplate,
+        ?int $phpVersionIdMinimumCompatibility,
+        ?int $phpVersionIdMaxCompatibility = null
+    ): string {
+        $flagsByPhpVersions = $this->flagsByVersion;
+        $phpVersions = ALL_PHP_VERSION_IDS;
+        sort($phpVersions);
+        $currentPhpVersion = end($phpVersions);
+
+        // No version compatibility is needed
+        if ($phpVersionIdMinimumCompatibility === null) {
+            if (empty($flagsByPhpVersions[$currentPhpVersion])) {
+                return '';
+            }
+            return sprintf($codeTemplate, implode("|", $flagsByPhpVersions[$currentPhpVersion]));
+        }
+
+        ksort($flagsByPhpVersions);
+        // Remove flags which depend on a PHP version below the minimally supported one
+        $index = array_search($phpVersionIdMinimumCompatibility, array_keys($flagsByPhpVersions));
+        if ($index === false) {
+            throw new Exception("Missing version dependent flags for PHP version ID \"$phpVersionIdMinimumCompatibility\"");
+        }
+        $flagsByPhpVersions = array_slice($flagsByPhpVersions, $index, null, true);
+        if ($phpVersionIdMaxCompatibility !== null) {
+            // Remove flags which depend on a PHP version above the maximally supported one
+            $index = array_search($phpVersionIdMaxCompatibility, array_keys($flagsByPhpVersions));
+            if ($index === false) {
+                throw new Exception("Missing version dependent flags for PHP version ID \"$phpVersionIdMaxCompatibility\"");
+            }
+            $flagsByPhpVersions = array_slice($flagsByPhpVersions, 0, $index, true);
+        }
+
+        // Remove version-specific flags which don't differ from the previous one
+        // Also populate '0' values
+        $previousVersionId = null;
+        foreach ($flagsByPhpVersions as $versionId => $versionFlags) {
+            if ($versionFlags === []) {
+                $versionFlags = ['0'];
+                $flagsByPhpVersions[$versionId] = ['0'];
+            }
+            if ($previousVersionId !== null && $flagsByPhpVersions[$previousVersionId] === $versionFlags) {
+                unset($flagsByPhpVersions[$versionId]);
+            } else {
+                $previousVersionId = $versionId;
+            }
+        }
+
+        $flagCount = count($flagsByPhpVersions);
+
+        // Do not add a condition unnecessarily when the only version is the same as the minimally supported one
+        if ($flagCount === 1) {
+            reset($flagsByPhpVersions);
+            $firstVersion = key($flagsByPhpVersions);
+            if ($firstVersion === $phpVersionIdMinimumCompatibility) {
+                return sprintf($codeTemplate, implode("|", reset($flagsByPhpVersions)));
+            }
+        }
+
+        // Add the necessary conditions around the code using the version-specific flags
+        $code = '';
+        $i = 0;
+        foreach (array_reverse($flagsByPhpVersions, true) as $version => $versionFlags) {
+            $if = $i === 0 ? "#if" : "#elif";
+            $endif = $i === $flagCount - 1 ? "#endif\n" : "";
+
+            $code .= "$if (PHP_VERSION_ID >= $version)\n";
+
+            $code .= sprintf($codeTemplate, implode("|", $versionFlags));
+            $code .= $endif;
+
+            $i++;
+        }
+
+        return $code;
+    }
+}
+
+class FuncInfo
+{
+    public /* readonly */ FunctionOrMethodName $name;
+    private /* readonly */ int $classFlags;
+    public int $flags;
+    public /* readonly */ ?string $aliasType;
+    public ?FunctionOrMethodName $alias;
+    private /* readonly */ bool $isDeprecated;
+    private bool $supportsCompileTimeEval;
+    public /* readonly */ bool $verify;
+    /** @var ArgInfo[] */
+    public /* readonly */ array $args;
+    public /* readonly */ ReturnInfo $return;
+    private /* readonly */ int $numRequiredArgs;
+    public /* readonly */ ?string $cond;
+    public bool $isUndocumentable;
+    private ?int $minimumPhpVersionIdCompatibility;
+    /** @var AttributeInfo[] */
+    public array $attributes;
+    /** @var FramelessFunctionInfo[] */
+    private array $framelessFunctionInfos;
+    private ?ExposedDocComment $exposedDocComment;
+
+    /**
+     * @param ArgInfo[] $args
+     * @param AttributeInfo[] $attributes
+     * @param FramelessFunctionInfo[] $framelessFunctionInfos
+     */
+    public function __construct(
+        FunctionOrMethodName $name,
+        int $classFlags,
+        int $flags,
+        ?string $aliasType,
+        ?FunctionOrMethodName $alias,
+        bool $isDeprecated,
+        bool $supportsCompileTimeEval,
+        bool $verify,
+        array $args,
+        ReturnInfo $return,
+        int $numRequiredArgs,
+        ?string $cond,
+        bool $isUndocumentable,
+        ?int $minimumPhpVersionIdCompatibility,
+        array $attributes,
+        array $framelessFunctionInfos,
+        ?ExposedDocComment $exposedDocComment
+    ) {
+        $this->name = $name;
+        $this->classFlags = $classFlags;
+        $this->flags = $flags;
+        $this->aliasType = $aliasType;
+        $this->alias = $alias;
+        $this->isDeprecated = $isDeprecated;
+        $this->supportsCompileTimeEval = $supportsCompileTimeEval;
+        $this->verify = $verify;
+        $this->args = $args;
+        $this->return = $return;
+        $this->numRequiredArgs = $numRequiredArgs;
+        $this->cond = $cond;
+        $this->isUndocumentable = $isUndocumentable;
+        $this->minimumPhpVersionIdCompatibility = $minimumPhpVersionIdCompatibility;
+        $this->attributes = $attributes;
+        $this->framelessFunctionInfos = $framelessFunctionInfos;
+        $this->exposedDocComment = $exposedDocComment;
+        if ($return->tentativeReturnType && $this->isFinalMethod()) {
+            throw new Exception("Tentative return inapplicable for final method");
+        }
+    }
+
+    public function isMethod(): bool
+    {
+        return $this->name instanceof MethodName;
+    }
+
+    private function isFinalMethod(): bool
+    {
+        return ($this->flags & Modifiers::FINAL) || ($this->classFlags & Modifiers::FINAL);
+    }
+
+    public function isInstanceMethod(): bool
+    {
+        return !($this->flags & Modifiers::STATIC) && $this->isMethod() && !$this->name->isConstructor();
+    }
+
+    /** @return string[] */
+    private function getModifierNames(): array
+    {
+        if (!$this->isMethod()) {
+            return [];
+        }
+
+        $result = [];
+
+        if ($this->flags & Modifiers::FINAL) {
+            $result[] = "final";
+        } elseif ($this->flags & Modifiers::ABSTRACT && $this->classFlags & ~Modifiers::ABSTRACT) {
+            $result[] = "abstract";
+        }
+
+        if ($this->flags & Modifiers::PROTECTED) {
+            $result[] = "protected";
+        } elseif ($this->flags & Modifiers::PRIVATE) {
+            $result[] = "private";
+        } else {
+            $result[] = "public";
+        }
+
+        if ($this->flags & Modifiers::STATIC) {
+            $result[] = "static";
+        }
+
+        return $result;
+    }
+
+    private function hasParamWithUnknownDefaultValue(): bool
+    {
+        foreach ($this->args as $arg) {
+            if ($arg->defaultValue && !$arg->hasProperDefaultValue()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function equalsApartFromNameAndRefcount(FuncInfo $other): bool
+    {
+        if (count($this->args) !== count($other->args)) {
+            return false;
+        }
+
+        for ($i = 0; $i < count($this->args); $i++) {
+            if (!$this->args[$i]->equals($other->args[$i])) {
+                return false;
+            }
+        }
+
+        return $this->return->equalsApartFromPhpDocAndRefcount($other->return)
+            && $this->numRequiredArgs === $other->numRequiredArgs
+            && $this->cond === $other->cond;
+    }
+
+    public function getArgInfoName(): string
+    {
+        return $this->name->getArgInfoName();
+    }
+
+    public function getDeclarationKey(): string
+    {
+        $name = $this->alias ?? $this->name;
+
+        return "$name|$this->cond";
+    }
+
+    public function getDeclaration(): ?string
+    {
+        if ($this->flags & Modifiers::ABSTRACT) {
+            return null;
+        }
+
+        $name = $this->alias ?? $this->name;
+
+        return $name->getDeclaration();
+    }
+
+    public function getFramelessDeclaration(): ?string
+    {
+        if (empty($this->framelessFunctionInfos)) {
+            return null;
+        }
+
+        $code = '';
+        $infos = '';
+        foreach ($this->framelessFunctionInfos as $framelessFunctionInfo) {
+            $code .= "ZEND_FRAMELESS_FUNCTION({$this->name->getFunctionName()}, {$framelessFunctionInfo->arity});\n";
+            $infos .= "\t{ ZEND_FRAMELESS_FUNCTION_NAME({$this->name->getFunctionName()}, {$framelessFunctionInfo->arity}), {$framelessFunctionInfo->arity} },\n";
+        }
+
+        $code .= 'static const zend_frameless_function_info ' . $this->getFramelessFunctionInfosName() . "[] = {\n";
+        $code .= $infos;
+        $code .= "\t{ 0 },\n";
+        $code .= "};\n";
+
+        $php84MinimumCompatibility = $this->minimumPhpVersionIdCompatibility === null || $this->minimumPhpVersionIdCompatibility >= PHP_84_VERSION_ID;
+        if (!$php84MinimumCompatibility) {
+            return "#if (PHP_VERSION_ID >= " . PHP_84_VERSION_ID . ")\n$code#endif\n";
+        }
+
+        return $code;
+    }
+
+    private function getFramelessFunctionInfosName(): string
+    {
+        return $this->name->getFramelessFunctionInfosName();
+    }
+
+    public function getFunctionEntry(): string
+    {
+        if (!empty($this->framelessFunctionInfos)) {
+            if ($this->isMethod()) {
+                throw new Exception('Frameless methods are not supported yet');
+            }
+            if ($this->name->getNamespace()) {
+                throw new Exception('Namespaced direct calls to frameless functions are not supported yet');
+            }
+            if ($this->alias) {
+                throw new Exception('Aliased direct calls to frameless functions are not supported yet');
+            }
+        }
+
+        $isVanillaEntry = $this->alias === null && !$this->supportsCompileTimeEval && $this->exposedDocComment === null && empty($this->framelessFunctionInfos);
+        $argInfoName = $this->getArgInfoName();
+        $flagsByPhpVersions = $this->getArginfoFlagsByPhpVersions();
+
+        if ($this->isMethod()) {
+            $zendName = '"' . $this->name->methodName . '"';
+            if ($this->alias) {
+                if ($this->alias instanceof MethodName) {
+                    $name = "zim_" . $this->alias->getDeclarationClassName() . "_" . $this->alias->methodName;
+                } else if ($this->alias instanceof FunctionName) {
+                    $name = "zif_" . $this->alias->getNonNamespacedName();
+                } else {
+                    throw new Error("Cannot happen");
+                }
+            } elseif ($this->flags & Modifiers::ABSTRACT) {
+                $name = "NULL";
+            } else {
+                $name = "zim_" . $this->name->getDeclarationClassName() . "_" . $this->name->methodName;
+
+                if ($isVanillaEntry) {
+                    $template = "\tZEND_ME(" . $this->name->getDeclarationClassName() . ", " . $this->name->methodName . ", $argInfoName, %s)\n";
+                    $flagsCode = $flagsByPhpVersions->generateVersionDependentFlagCode(
+                        $template,
+                        $this->minimumPhpVersionIdCompatibility
+                    );
+                    return rtrim($flagsCode) . "\n";
+                }
+            }
+        } else if ($this->name instanceof FunctionName) {
+            $functionName = $this->name->getFunctionName();
+            $declarationName = $this->alias ? $this->alias->getNonNamespacedName() : $this->name->getDeclarationName();
+            $name = "zif_$declarationName";
+
+            if ($this->name->getNamespace()) {
+                $namespace = addslashes($this->name->getNamespace());
+                $zendName = "ZEND_NS_NAME(\"$namespace\", \"$functionName\")";
+            } else {
+                // Can only use ZEND_FE() if we have no flags for *all* versions
+                if ($isVanillaEntry && $flagsByPhpVersions->isEmpty()) {
+                    return "\tZEND_FE($declarationName, $argInfoName)\n";
+                }
+                $zendName = '"' . $functionName . '"';
+            }
+        } else {
+            throw new Error("Cannot happen");
+        }
+
+        $docComment = $this->exposedDocComment ? '"' . $this->exposedDocComment->escape() . '"' : "NULL";
+        $framelessFuncInfosName = !empty($this->framelessFunctionInfos) ? $this->getFramelessFunctionInfosName() : "NULL";
+
+        // Assume 8.4+ here, if older versions are supported this is conditional
+        $code = $flagsByPhpVersions->generateVersionDependentFlagCode(
+            "\tZEND_RAW_FENTRY($zendName, $name, $argInfoName, %s, $framelessFuncInfosName, $docComment)\n",
+            PHP_84_VERSION_ID
+        );
+
+        $php84MinimumCompatibility = $this->minimumPhpVersionIdCompatibility === null || $this->minimumPhpVersionIdCompatibility >= PHP_84_VERSION_ID;
+        if (!$php84MinimumCompatibility) {
+            $code = "#if (PHP_VERSION_ID >= " . PHP_84_VERSION_ID . ")\n$code";
+            $code .= "#else\n";
+
+            $code .= $flagsByPhpVersions->generateVersionDependentFlagCode(
+                "\tZEND_RAW_FENTRY($zendName, $name, $argInfoName, %s)\n",
+                $this->minimumPhpVersionIdCompatibility,
+                PHP_83_VERSION_ID
+            );
+
+            $code .= "#endif\n";
+        }
+
+        return $code;
+    }
+
+    public function getOptimizerInfo(): ?string
+    {
+        if ($this->isMethod()) {
+            return null;
+        }
+
+        if ($this->alias !== null) {
+            return null;
+        }
+
+        if ($this->return->refcount !== ReturnInfo::REFCOUNT_1 && $this->return->phpDocType === null) {
+            return null;
+        }
+
+        $type = $this->return->phpDocType ?? $this->return->type;
+        if ($type === null) {
+            return null;
+        }
+
+        return "\tF" . $this->return->refcount . '("' . addslashes($this->name->__toString()) . '", ' . $type->toOptimizerTypeMask() . "),\n";
+    }
+
+    public function discardInfoForOldPhpVersions(?int $minimumPhpVersionIdCompatibility): void
+    {
+        $this->attributes = [];
+        $this->return->type = null;
+        $this->framelessFunctionInfos = [];
+        $this->exposedDocComment = null;
+        $this->supportsCompileTimeEval = false;
+        foreach ($this->args as $arg) {
+            $arg->type = null;
+            $arg->defaultValue = null;
+            $arg->attributes = [];
+        }
+        $this->minimumPhpVersionIdCompatibility = $minimumPhpVersionIdCompatibility;
+    }
+
+    private function getArginfoFlagsByPhpVersions(): VersionFlags
+    {
+        $flags = [];
+
+        if ($this->isMethod()) {
+            if ($this->flags & Modifiers::PROTECTED) {
+                $flags[] = "ZEND_ACC_PROTECTED";
+            } elseif ($this->flags & Modifiers::PRIVATE) {
+                $flags[] = "ZEND_ACC_PRIVATE";
+            } else {
+                $flags[] = "ZEND_ACC_PUBLIC";
+            }
+
+            if ($this->flags & Modifiers::STATIC) {
+                $flags[] = "ZEND_ACC_STATIC";
+            }
+
+            if ($this->flags & Modifiers::FINAL) {
+                $flags[] = "ZEND_ACC_FINAL";
+            }
+
+            if ($this->flags & Modifiers::ABSTRACT) {
+                $flags[] = "ZEND_ACC_ABSTRACT";
+            }
+        }
+
+        if ($this->isDeprecated) {
+            $flags[] = "ZEND_ACC_DEPRECATED";
+        }
+
+        foreach ($this->attributes as $attr) {
+            switch ($attr->class) {
+                case "Deprecated":
+                    $flags[] = "ZEND_ACC_DEPRECATED";
+                    break;
+            }
+        }
+
+        $flags = new VersionFlags($flags);
+
+        if ($this->isMethod() === false && $this->supportsCompileTimeEval) {
+            $flags->addForVersionsAbove("ZEND_ACC_COMPILE_TIME_EVAL", PHP_82_VERSION_ID);
+        }
+
+        foreach ($this->attributes as $attr) {
+            switch ($attr->class) {
+                case "NoDiscard":
+                    $flags->addForVersionsAbove("ZEND_ACC_NODISCARD", PHP_85_VERSION_ID);
+                    break;
+            }
+        }
+
+        return $flags;
+    }
+
+    private function generateRefSect1(DOMDocument $doc, string $role): DOMElement
+    {
+        $refSec = $doc->createElement('refsect1');
+        $refSec->setAttribute('role', $role);
+        $refSec->append(
+            "\n  ",
+            $doc->createEntityReference('reftitle.' . $role),
+            "\n  "
+        );
+        return $refSec;
+    }
+
+    public function getMethodSynopsisDocument(): ?string
+    {
+        $REFSEC1_SEPERATOR = "\n\n ";
+
+        $doc = new DOMDocument("1.0", "utf-8");
+        $doc->formatOutput = true;
+
+        $refentry = $doc->createElement('refentry');
+        $doc->appendChild($refentry);
+
+        if ($this->isMethod()) {
+            assert($this->name instanceof MethodName);
+            /* Namespaces are seperated by '-', '_' must be converted to '-' too.
+             * Trim away the __ for magic methods */
+            $id = strtolower(
+                str_replace('\\', '-', $this->name->className->__toString())
+                    . '.'
+                    . str_replace('_', '-', ltrim($this->name->methodName, '_'))
+            );
+        } else {
+            $id = 'function.' . strtolower(str_replace('_', '-', $this->name->__toString()));
+        }
+        $refentry->setAttribute("xml:id", $id);
+        /* We create an attribute for xmlns, as libxml otherwise force it to be the first one */
+        //$refentry->setAttribute("xmlns", "http://docbook.org/ns/docbook");
+        $namespace = $doc->createAttribute('xmlns');
+        $namespace->value = "http://docbook.org/ns/docbook";
+        $refentry->setAttributeNode($namespace);
+        $refentry->setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+        $refentry->appendChild(new DOMText("\n "));
+
+        /* Creation of <refnamediv> */
+        $refnamediv = $doc->createElement('refnamediv');
+        $refnamediv->appendChild(new DOMText("\n  "));
+        $refname = $doc->createElement('refname', $this->name->__toString());
+        $refnamediv->appendChild($refname);
+        $refnamediv->appendChild(new DOMText("\n  "));
+        $refpurpose = $doc->createElement('refpurpose', 'Description');
+        $refnamediv->appendChild($refpurpose);
+
+        $refnamediv->appendChild(new DOMText("\n "));
+        $refentry->append($refnamediv, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="description"> */
+        $descriptionRefSec = $this->generateRefSect1($doc, 'description');
+
+        $methodSynopsis = $this->getMethodSynopsisElement($doc);
+        if (!$methodSynopsis) {
+            return null;
+        }
+        $descriptionRefSec->appendChild($methodSynopsis);
+        $descriptionRefSec->appendChild(new DOMText("\n  "));
+        $undocumentedEntity = $doc->createEntityReference('warn.undocumented.func');
+        $descriptionRefSec->appendChild($undocumentedEntity);
+        $descriptionRefSec->appendChild(new DOMText("\n  "));
+        $returnDescriptionPara = $doc->createElement('simpara');
+        $returnDescriptionPara->appendChild(new DOMText("\n   Description.\n  "));
+        $descriptionRefSec->appendChild($returnDescriptionPara);
+
+        $descriptionRefSec->appendChild(new DOMText("\n "));
+        $refentry->append($descriptionRefSec, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="parameters"> */
+        $parametersRefSec = $this->getParameterSection($doc);
+        $refentry->append($parametersRefSec, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="returnvalues"> */
+        if (!$this->name->isConstructor() && !$this->name->isDestructor()) {
+            $returnRefSec = $this->getReturnValueSection($doc);
+            $refentry->append($returnRefSec, $REFSEC1_SEPERATOR);
+        }
+
+        /* Creation of <refsect1 role="errors"> */
+        $errorsRefSec = $this->generateRefSect1($doc, 'errors');
+        $errorsDescriptionParaConstantTag = $doc->createElement('constant');
+        $errorsDescriptionParaConstantTag->append('E_*');
+        $errorsDescriptionParaExceptionTag = $doc->createElement('exceptionname');
+        $errorsDescriptionParaExceptionTag->append('Exception');
+        $errorsDescriptionPara = $doc->createElement('simpara');
+        $errorsDescriptionPara->append(
+            "\n   When does this function issue ",
+            $errorsDescriptionParaConstantTag,
+            " level errors,\n   and/or throw ",
+            $errorsDescriptionParaExceptionTag,
+            "s.\n  "
+        );
+        $errorsRefSec->appendChild($errorsDescriptionPara);
+        $errorsRefSec->appendChild(new DOMText("\n "));
+
+        $refentry->append($errorsRefSec, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="changelog"> */
+        $changelogRefSec = $this->getChangelogSection($doc);
+        $refentry->append($changelogRefSec, $REFSEC1_SEPERATOR);
+
+        $exampleRefSec = $this->getExampleSection($doc, $id);
+        $refentry->append($exampleRefSec, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="notes"> */
+        $notesRefSec = $this->generateRefSect1($doc, 'notes');
+
+        $noteTagSimara = $doc->createElement('simpara');
+        $noteTagSimara->append(
+            "\n    Any notes that don't fit anywhere else should go here.\n   "
+        );
+        $noteTag = $doc->createElement('note');
+        $noteTag->append("\n   ", $noteTagSimara, "\n  ");
+        $notesRefSec->append($noteTag, "\n ");
+
+        $refentry->append($notesRefSec, $REFSEC1_SEPERATOR);
+
+        /* Creation of <refsect1 role="seealso"> */
+        $seeAlsoRefSec = $this->generateRefSect1($doc, 'seealso');
+
+        $seeAlsoMemberClassMethod = $doc->createElement('member');
+        $seeAlsoMemberClassMethodTag = $doc->createElement('methodname');
+        $seeAlsoMemberClassMethodTag->appendChild(new DOMText("ClassName::otherMethodName"));
+        $seeAlsoMemberClassMethod->appendChild($seeAlsoMemberClassMethodTag);
+
+        $seeAlsoMemberFunction = $doc->createElement('member');
+        $seeAlsoMemberFunctionTag = $doc->createElement('function');
+        $seeAlsoMemberFunctionTag->appendChild(new DOMText("some_function"));
+        $seeAlsoMemberFunction->appendChild($seeAlsoMemberFunctionTag);
+
+        $seeAlsoMemberLink = $doc->createElement('member');
+        $seeAlsoMemberLinkTag = $doc->createElement('link');
+        $seeAlsoMemberLinkTag->setAttribute('linkend', 'some.id.chunk.to.link');
+        $seeAlsoMemberLinkTag->appendChild(new DOMText('something appendix'));
+        $seeAlsoMemberLink->appendChild($seeAlsoMemberLinkTag);
+
+        $seeAlsoList = $doc->createElement('simplelist');
+        $seeAlsoList->append(
+            "\n   ",
+            $seeAlsoMemberClassMethod,
+            "\n   ",
+            $seeAlsoMemberFunction,
+            "\n   ",
+            $seeAlsoMemberLink,
+            "\n  "
+        );
+
+        $seeAlsoRefSec->appendChild($seeAlsoList);
+        $seeAlsoRefSec->appendChild(new DOMText("\n "));
+
+        $refentry->appendChild($seeAlsoRefSec);
+
+        $refentry->appendChild(new DOMText("\n\n"));
+
+        $doc->appendChild(new DOMComment(
+            <<<ENDCOMMENT
+ Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+
+ENDCOMMENT
+        ));
+        return $doc->saveXML();
+    }
+
+    private function getParameterSection(DOMDocument $doc): DOMElement
+    {
+        $parametersRefSec = $this->generateRefSect1($doc, 'parameters');
+        if (empty($this->args)) {
+            $noParamEntity = $doc->createEntityReference('no.function.parameters');
+            $parametersRefSec->appendChild($noParamEntity);
+            return $parametersRefSec;
+        } else {
+            $parametersContainer = $doc->createDocumentFragment();
+
+            $parametersContainer->appendChild(new DOMText("\n  "));
+            $parametersList = $doc->createElement('variablelist');
+            $parametersContainer->appendChild($parametersList);
+
+            /*
+            <varlistentry>
+             <term><parameter>name</parameter></term>
+             <listitem>
+              <simpara>
+               Description.
+              </simpara>
+             </listitem>
+            </varlistentry>
+            */
+            foreach ($this->args as $arg) {
+                $parameter = $doc->createElement('parameter', $arg->name);
+                $parameterTerm = $doc->createElement('term');
+                $parameterTerm->appendChild($parameter);
+
+                $listItemPara = $doc->createElement('simpara');
+                $listItemPara->append(
+                    "\n      ",
+                    "Description.",
+                    "\n     ",
+                );
+
+                $parameterEntryListItem = $doc->createElement('listitem');
+                $parameterEntryListItem->append(
+                    "\n     ",
+                    $listItemPara,
+                    "\n    ",
+                );
+
+                $parameterEntry = $doc->createElement('varlistentry');
+                $parameterEntry->append(
+                    "\n    ",
+                    $parameterTerm,
+                    "\n    ",
+                    $parameterEntryListItem,
+                    "\n   ",
+                );
+
+                $parametersList->appendChild(new DOMText("\n   "));
+                $parametersList->appendChild($parameterEntry);
+            }
+            $parametersList->appendChild(new DOMText("\n  "));
+        }
+        $parametersContainer->appendChild(new DOMText("\n "));
+        $parametersRefSec->appendChild($parametersContainer);
+        $parametersRefSec->appendChild(new DOMText("\n "));
+        return $parametersRefSec;
+    }
+
+    private function getReturnValueSection(DOMDocument $doc): DOMElement
+    {
+        $returnRefSec = $this->generateRefSect1($doc, 'returnvalues');
+
+        $returnDescriptionPara = $doc->createElement('simpara');
+        $returnDescriptionPara->appendChild(new DOMText("\n   "));
+
+        $returnType = $this->return->getMethodSynopsisType();
+        if ($returnType === null) {
+            $returnDescriptionPara->appendChild(new DOMText("Description."));
+        } else if (count($returnType->types) === 1) {
+            $type = $returnType->types[0];
+
+            switch ($type->name) {
+                case 'void':
+                    $descriptionNode = $doc->createEntityReference('return.void');
+                    break;
+                case 'true':
+                    $descriptionNode = $doc->createEntityReference('return.true.always');
+                    break;
+                case 'bool':
+                    $descriptionNode = $doc->createEntityReference('return.success');
+                    break;
+                default:
+                    $descriptionNode = new DOMText("Description.");
+                    break;
+            }
+            $returnDescriptionPara->appendChild($descriptionNode);
+        } else {
+            $returnDescriptionPara->appendChild(new DOMText("Description."));
+        }
+        $returnDescriptionPara->appendChild(new DOMText("\n  "));
+        $returnRefSec->appendChild($returnDescriptionPara);
+        $returnRefSec->appendChild(new DOMText("\n "));
+        return $returnRefSec;
+    }
+
+    /**
+     * @param array<DOMNode> $headers [count($headers) === $columns]
+     * @param array<array<DOMNode>> $rows [count($rows[$i]) === $columns]
+     */
+    private function generateDocbookInformalTable(
+        DOMDocument $doc,
+        int $indent,
+        int $columns,
+        array $headers,
+        array $rows
+    ): DOMElement {
+        $strIndent = str_repeat(' ', $indent);
+
+        $headerRow = $doc->createElement('row');
+        foreach ($headers as $header) {
+            $headerEntry = $doc->createElement('entry');
+            $headerEntry->appendChild($header);
+
+            $headerRow->append("\n$strIndent    ", $headerEntry);
+        }
+        $headerRow->append("\n$strIndent   ");
+
+        $thead = $doc->createElement('thead');
+        $thead->append(
+            "\n$strIndent   ",
+            $headerRow,
+            "\n$strIndent  ",
+        );
+
+        $tbody = $doc->createElement('tbody');
+        foreach ($rows as $row) {
+            $bodyRow = $doc->createElement('row');
+            foreach ($row as $cell) {
+                $entry = $doc->createElement('entry');
+                $entry->appendChild($cell);
+
+                $bodyRow->appendChild(new DOMText("\n$strIndent    "));
+                $bodyRow->appendChild($entry);
+            }
+            $bodyRow->appendChild(new DOMText("\n$strIndent   "));
+
+            $tbody->append(
+                "\n$strIndent   ",
+                $bodyRow,
+                "\n$strIndent  ",
+            );
+        }
+
+        $tgroup = $doc->createElement('tgroup');
+        $tgroup->setAttribute('cols', (string) $columns);
+        $tgroup->append(
+            "\n$strIndent  ",
+            $thead,
+            "\n$strIndent  ",
+            $tbody,
+            "\n$strIndent ",
+        );
+
+        $table = $doc->createElement('informaltable');
+        $table->append(
+            "\n$strIndent ",
+            $tgroup,
+            "\n$strIndent",
+        );
+
+        return $table;
+    }
+
+    private function getChangelogSection(DOMDocument $doc): DOMElement
+    {
+        $refSec = $this->generateRefSect1($doc, 'changelog');
+        $headers = [
+            $doc->createEntityReference('Version'),
+            $doc->createEntityReference('Description'),
+        ];
+        $rows = [[
+            new DOMText('8.X.0'),
+            new DOMText("\n       Description\n      "),
+        ]];
+        $table = $this->generateDocbookInformalTable(
+            $doc,
+            /* indent: */
+            2,
+            /* columns: */
+            2,
+            /* headers: */
+            $headers,
+            /* rows: */
+            $rows
+        );
+        $refSec->appendChild($table);
+
+        $refSec->appendChild(new DOMText("\n "));
+        return $refSec;
+    }
+
+    private function getExampleSection(DOMDocument $doc, string $id): DOMElement
+    {
+        $refSec = $this->generateRefSect1($doc, 'examples');
+
+        $example = $doc->createElement('example');
+        $fnName = $this->name->__toString();
+        $example->setAttribute('xml:id', $id . '.example.basic');
+
+        $title = $doc->createElement('title');
+        $fn = $doc->createElement($this->isMethod() ? 'methodname' : 'function');
+        $fn->append($fnName);
+        $title->append($fn, ' example');
+
+        $example->append("\n   ", $title);
+
+        $para = $doc->createElement('simpara');
+        $para->append("\n    ", "Description.", "\n   ");
+        $example->append("\n   ", $para);
+
+        $prog = $doc->createElement('programlisting');
+        $prog->setAttribute('role', 'php');
+        // So that GitHub syntax highlighting doesn't treat the closing tag
+        // in the DOMCdataSection as indication that it should stop syntax
+        // highlighting, break it up
+        $empty = '';
+        $code = new DOMCdataSection(
+            <<<CODE_EXAMPLE
+
+<?php
+echo "Code example";
+?$empty>
+
+CODE_EXAMPLE
+        );
+        $prog->append("\n");
+        $prog->appendChild($code);
+        $prog->append("\n   ");
+
+        $example->append("\n   ", $prog);
+        $example->append("\n   ", $doc->createEntityReference('example.outputs'));
+
+        $output = new DOMCdataSection(
+            <<<OUPUT_EXAMPLE
+
+Code example
+
+OUPUT_EXAMPLE
+        );
+        $screen = $doc->createElement('screen');
+        $screen->append("\n");
+        $screen->appendChild($output);
+        $screen->append("\n   ");
+
+        $example->append(
+            "\n   ",
+            $screen,
+            "\n  ",
+        );
+
+        $refSec->append(
+            $example,
+            "\n ",
+        );
+        return $refSec;
+    }
+
+    public function getMethodSynopsisElement(DOMDocument $doc): ?DOMElement
+    {
+        if ($this->hasParamWithUnknownDefaultValue()) {
+            return null;
+        }
+
+        if ($this->name->isConstructor()) {
+            $synopsisType = "constructorsynopsis";
+        } elseif ($this->name->isDestructor()) {
+            $synopsisType = "destructorsynopsis";
+        } else {
+            $synopsisType = "methodsynopsis";
+        }
+
+        $methodSynopsis = $doc->createElement($synopsisType);
+
+        if ($this->isMethod()) {
+            assert($this->name instanceof MethodName);
+            $role = $doc->createAttribute("role");
+            $role->value = addslashes($this->name->className->__toString());
+            $methodSynopsis->appendChild($role);
+        }
+
+        $methodSynopsis->appendChild(new DOMText("\n   "));
+
+        foreach ($this->attributes as $attribute) {
+            $modifier = $doc->createElement("modifier", "#[\\" . $attribute->class . "]");
+            $modifier->setAttribute("role", "attribute");
+            $methodSynopsis->appendChild($modifier);
+            $methodSynopsis->appendChild(new DOMText("\n   "));
+        }
+
+        foreach ($this->getModifierNames() as $modifierString) {
+            $modifierElement = $doc->createElement('modifier', $modifierString);
+            $methodSynopsis->appendChild($modifierElement);
+            $methodSynopsis->appendChild(new DOMText(" "));
+        }
+
+        $returnType = $this->return->getMethodSynopsisType();
+        if ($returnType) {
+            $methodSynopsis->appendChild($returnType->getTypeForDoc($doc));
+        }
+
+        $methodname = $doc->createElement('methodname', $this->name->__toString());
+        $methodSynopsis->appendChild($methodname);
+
+        if (empty($this->args)) {
+            $methodSynopsis->appendChild(new DOMText("\n   "));
+            $void = $doc->createElement('void');
+            $methodSynopsis->appendChild($void);
+        } else {
+            foreach ($this->args as $arg) {
+                $methodSynopsis->appendChild(new DOMText("\n   "));
+                $methodparam = $doc->createElement('methodparam');
+                if ($arg->defaultValue !== null) {
+                    $methodparam->setAttribute("choice", "opt");
+                }
+                if ($arg->isVariadic) {
+                    $methodparam->setAttribute("rep", "repeat");
+                }
+
+                $methodSynopsis->appendChild($methodparam);
+                foreach ($arg->attributes as $attribute) {
+                    $attribute = $doc->createElement("modifier", "#[\\" . $attribute->class . "]");
+                    $attribute->setAttribute("role", "attribute");
+
+                    $methodparam->appendChild($attribute);
+                }
+
+                $methodparam->appendChild($arg->getMethodSynopsisType()->getTypeForDoc($doc));
+
+                $parameter = $doc->createElement('parameter', $arg->name);
+                if ($arg->sendBy !== ArgInfo::SEND_BY_VAL) {
+                    $parameter->setAttribute("role", "reference");
+                }
+
+                $methodparam->appendChild($parameter);
+                $defaultValue = $arg->getDefaultValueAsMethodSynopsisString();
+                if ($defaultValue !== null) {
+                    $initializer = $doc->createElement('initializer');
+                    if (preg_match('/^[a-zA-Z_][a-zA-Z_0-9]*$/', $defaultValue)) {
+                        $constant = $doc->createElement('constant', $defaultValue);
+                        $initializer->appendChild($constant);
+                    } else {
+                        $initializer->nodeValue = $defaultValue;
+                    }
+                    $methodparam->appendChild($initializer);
+                }
+            }
+        }
+        $methodSynopsis->appendChild(new DOMText("\n  "));
+
+        return $methodSynopsis;
+    }
+
+    /** @param FuncInfo[] $generatedFuncInfos */
+    public function findEquivalent(array $generatedFuncInfos): ?FuncInfo
+    {
+        foreach ($generatedFuncInfos as $generatedFuncInfo) {
+            if ($generatedFuncInfo->equalsApartFromNameAndRefcount($this)) {
+                return $generatedFuncInfo;
+            }
+        }
+        return null;
+    }
+
+    public function toArgInfoCode(?int $minPHPCompatability): string
+    {
+        $code = $this->return->beginArgInfo(
+            $this->getArgInfoName(),
+            $this->numRequiredArgs,
+            $minPHPCompatability === null || $minPHPCompatability >= PHP_81_VERSION_ID
+        );
+
+        foreach ($this->args as $argInfo) {
+            $code .= $argInfo->toZendInfo();
+        }
+
+        $code .= "ZEND_END_ARG_INFO()";
+        return $code . "\n";
+    }
+
+    public function __clone()
+    {
+        foreach ($this->args as $key => $argInfo) {
+            $this->args[$key] = clone $argInfo;
+        }
+        $this->return = clone $this->return;
+    }
+}
+
+class EvaluatedValue
+{
+    public /* readonly */ mixed $value;
+    public SimpleType $type;
+    public Expr $expr;
+    public bool $isUnknownConstValue;
+    /** @var ConstInfo[] */
+    public array $originatingConsts;
+
+    /**
+     * @param array<string, ConstInfo> $allConstInfos
+     */
+    public static function createFromExpression(Expr $expr, ?SimpleType $constType, ?string $cConstName, array $allConstInfos): EvaluatedValue
+    {
+        // This visitor replaces the PHP constants by C constants. It allows direct expansion of the compiled constants, e.g. later in the pretty printer.
+        $visitor = new class($allConstInfos) extends PhpParser\NodeVisitorAbstract
+        {
+            /** @var iterable<ConstInfo> */
+            public array $visitedConstants = [];
+            /** @var array<string, ConstInfo> */
+            public array $allConstInfos;
+
+            /** @param array<string, ConstInfo> $allConstInfos */
+            public function __construct(array $allConstInfos)
+            {
+                $this->allConstInfos = $allConstInfos;
+            }
+
+            /** @return Node|null */
+            public function enterNode(Node $expr)
+            {
+                if (!$expr instanceof Expr\ConstFetch && !$expr instanceof Expr\ClassConstFetch) {
+                    return null;
+                }
+
+                if ($expr instanceof Expr\ClassConstFetch) {
+                    $originatingConstName = new ClassConstName($expr->class, $expr->name->toString());
+                } else {
+                    $originatingConstName = new ConstName($expr->name->getAttribute('namespacedName'), $expr->name->toString());
+                }
+
+                if ($originatingConstName->isUnknown()) {
+                    return null;
+                }
+
+                $const = $this->allConstInfos[$originatingConstName->__toString()] ?? null;
+                if ($const !== null) {
+                    $this->visitedConstants[] = $const;
+                    return $const->getValue($this->allConstInfos)->expr;
+                }
+            }
+        };
+
+        $nodeTraverser = new PhpParser\NodeTraverser;
+        $nodeTraverser->addVisitor($visitor);
+        $expr = $nodeTraverser->traverse([$expr])[0];
+
+        $isUnknownConstValue = false;
+
+        $evaluator = new ConstExprEvaluator(
+            static function (Expr $expr) use ($allConstInfos, &$isUnknownConstValue) {
+                // $expr is a ConstFetch with a name of a C macro here
+                if (!$expr instanceof Expr\ConstFetch) {
+                    throw new Exception("Expression at line " . $expr->getStartLine() . " must be a global, non-magic constant");
+                }
+
+                $constName = $expr->name->__toString();
+                if (strtolower($constName) === "unknown") {
+                    $isUnknownConstValue = true;
+                    return null;
+                }
+
+                foreach ($allConstInfos as $const) {
+                    if ($constName != $const->cValue) {
+                        continue;
+                    }
+
+                    $constType = ($const->phpDocType ?? $const->type)->tryToSimpleType();
+                    if ($constType) {
+                        if ($constType->isBool()) {
+                            return true;
+                        } elseif ($constType->isInt()) {
+                            return 1;
+                        } elseif ($constType->isFloat()) {
+                            return M_PI;
+                        } elseif ($constType->isString()) {
+                            return $const->name;
+                        } elseif ($constType->isArray()) {
+                            return [];
+                        }
+                    }
+
+                    return null;
+                }
+
+                throw new Exception("Constant " . $constName . " cannot be found");
+            }
+        );
+
+        $result = $evaluator->evaluateDirectly($expr);
+
+        return new EvaluatedValue(
+            $result, // note: we are generally not interested in the actual value of $result, unless it's a bare value, without constants
+            $constType ?? SimpleType::fromValue($result),
+            $cConstName === null ? $expr : new Expr\ConstFetch(new Node\Name($cConstName)),
+            $visitor->visitedConstants,
+            $isUnknownConstValue
+        );
+    }
+
+    public static function null(): EvaluatedValue
+    {
+        return new self(null, SimpleType::null(), new Expr\ConstFetch(new Node\Name('null')), [], false);
+    }
+
+    /**
+     * @param mixed $value
+     * @param ConstInfo[] $originatingConsts
+     */
+    private function __construct($value, SimpleType $type, Expr $expr, array $originatingConsts, bool $isUnknownConstValue)
+    {
+        $this->value = $value;
+        $this->type = $type;
+        $this->expr = $expr;
+        $this->originatingConsts = $originatingConsts;
+        $this->isUnknownConstValue = $isUnknownConstValue;
+    }
+
+    public function initializeZval(string $zvalName, bool $alreadyExists = false, string $forStringDef = ''): string
+    {
+        $cExpr = $this->getCExpr();
+
+        $code = '';
+        if (!$alreadyExists) {
+            $code = "\tzval $zvalName;\n";
+        }
+
+        if ($this->type->isNull()) {
+            $code .= "\tZVAL_NULL(&$zvalName);\n";
+        } elseif ($this->type->isBool()) {
+            if ($cExpr == 'true') {
+                $code .= "\tZVAL_TRUE(&$zvalName);\n";
+            } elseif ($cExpr == 'false') {
+                $code .= "\tZVAL_FALSE(&$zvalName);\n";
+            } else {
+                $code .= "\tZVAL_BOOL(&$zvalName, $cExpr);\n";
+            }
+        } elseif ($this->type->isInt()) {
+            $code .= "\tZVAL_LONG(&$zvalName, $cExpr);\n";
+        } elseif ($this->type->isFloat()) {
+            $code .= "\tZVAL_DOUBLE(&$zvalName, $cExpr);\n";
+        } elseif ($this->type->isString()) {
+            if ($cExpr === '""') {
+                $code .= "\tZVAL_EMPTY_STRING(&$zvalName);\n";
+            } else {
+                if ($forStringDef === '') {
+                    $forStringDef = "{$zvalName}_str";
+                }
+                $code .= "\tzend_string *$forStringDef = zend_string_init($cExpr, strlen($cExpr), 1);\n";
+                $code .= "\tZVAL_STR(&$zvalName, $forStringDef);\n";
+            }
+        } elseif ($this->type->isArray()) {
+            if ($cExpr == '[]') {
+                $code .= "\tZVAL_EMPTY_ARRAY(&$zvalName);\n";
+            } else {
+                throw new Exception("Unimplemented default value");
+            }
+        } else {
+            throw new Exception("Invalid default value: " . print_r($this->value, true) . ", type: " . print_r($this->type, true));
+        }
+
+        return $code;
+    }
+
+    public function getCExpr(): ?string
+    {
+        // $this->expr has all its PHP constants replaced by C constants
+        $prettyPrinter = new Standard;
+        $expr = $prettyPrinter->prettyPrintExpr($this->expr);
+        // PHP single-quote to C double-quote string
+        if ($this->type->isString()) {
+            $expr = preg_replace("/(^'|'$)/", '"', $expr);
+        }
+        return $expr[0] == '"' ? $expr : preg_replace('(\bnull\b)', 'NULL', str_replace('\\', '', $expr));
+    }
+}
+
+abstract class VariableLike
+{
+    protected int $flags;
+    public ?Type $type;
+    public /* readonly */ ?Type $phpDocType;
+    private /* readonly */ ?string $link;
+    protected ?int $phpVersionIdMinimumCompatibility;
+    /** @var AttributeInfo[] */
+    public array $attributes;
+    protected /* readonly */ ?ExposedDocComment $exposedDocComment;
+
+    /**
+     * @param AttributeInfo[] $attributes
+     */
+    public function __construct(
+        int $flags,
+        ?Type $type,
+        ?Type $phpDocType,
+        ?string $link,
+        ?int $phpVersionIdMinimumCompatibility,
+        array $attributes,
+        ?ExposedDocComment $exposedDocComment
+    ) {
+        $this->flags = $flags;
+        $this->type = $type;
+        $this->phpDocType = $phpDocType;
+        $this->link = $link;
+        $this->phpVersionIdMinimumCompatibility = $phpVersionIdMinimumCompatibility;
+        $this->attributes = $attributes;
+        $this->exposedDocComment = $exposedDocComment;
+    }
+
+    abstract protected function getVariableTypeName(): string;
+
+    abstract protected function getFieldSynopsisDefaultLinkend(): string;
+
+    abstract protected function getFieldSynopsisName(): string;
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    abstract protected function getFieldSynopsisValueString(array $allConstInfos): ?string;
+
+    abstract public function discardInfoForOldPhpVersions(?int $minimumPhpVersionIdCompatibility): void;
+
+    protected function getFlagsByPhpVersion(): VersionFlags
+    {
+        $flags = "ZEND_ACC_PUBLIC";
+        if ($this->flags & Modifiers::PROTECTED) {
+            $flags = "ZEND_ACC_PROTECTED";
+        } elseif ($this->flags & Modifiers::PRIVATE) {
+            $flags = "ZEND_ACC_PRIVATE";
+        }
+
+        return new VersionFlags([$flags]);
+    }
+
+    protected function getTypeCode(string $variableLikeName, string &$code): string
+    {
+        $variableLikeType = $this->getVariableTypeName();
+
+        $typeCode = "";
+        if ($this->type) {
+            $arginfoType = $this->type->toArginfoType();
+            if ($arginfoType->hasClassType()) {
+                if (count($arginfoType->classTypes) >= 2) {
+                    foreach ($arginfoType->classTypes as $classType) {
+                        $escapedClassName = $classType->toEscapedName();
+                        $varEscapedClassName = $classType->toVarEscapedName();
+                        $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\") - 1, 1);\n";
+                    }
+
+                    $classTypeCount = count($arginfoType->classTypes);
+                    $code .= "\tzend_type_list *{$variableLikeType}_{$variableLikeName}_type_list = malloc(ZEND_TYPE_LIST_SIZE($classTypeCount));\n";
+                    $code .= "\t{$variableLikeType}_{$variableLikeName}_type_list->num_types = $classTypeCount;\n";
+
+                    foreach ($arginfoType->classTypes as $k => $classType) {
+                        $escapedClassName = $classType->toEscapedName();
+                        $code .= "\t{$variableLikeType}_{$variableLikeName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS({$variableLikeType}_{$variableLikeName}_class_{$escapedClassName}, 0, 0);\n";
+                    }
+
+                    $typeMaskCode = $this->type->toArginfoType()->toTypeMask();
+
+                    if ($this->type->isIntersection) {
+                        $code .= "\tzend_type {$variableLikeType}_{$variableLikeName}_type = ZEND_TYPE_INIT_INTERSECTION({$variableLikeType}_{$variableLikeName}_type_list, $typeMaskCode);\n";
+                    } else {
+                        $code .= "\tzend_type {$variableLikeType}_{$variableLikeName}_type = ZEND_TYPE_INIT_UNION({$variableLikeType}_{$variableLikeName}_type_list, $typeMaskCode);\n";
+                    }
+                    $typeCode = "{$variableLikeType}_{$variableLikeName}_type";
+                } else {
+                    $escapedClassName = $arginfoType->classTypes[0]->toEscapedName();
+                    $varEscapedClassName = $arginfoType->classTypes[0]->toVarEscapedName();
+                    $code .= "\tzend_string *{$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\")-1, 1);\n";
+
+                    $typeCode = "(zend_type) ZEND_TYPE_INIT_CLASS({$variableLikeType}_{$variableLikeName}_class_{$varEscapedClassName}, 0, " . $arginfoType->toTypeMask() . ")";
+                }
+            } else {
+                $typeCode = "(zend_type) ZEND_TYPE_INIT_MASK(" . $arginfoType->toTypeMask() . ")";
+            }
+        } else {
+            $typeCode = "(zend_type) ZEND_TYPE_INIT_NONE(0)";
+        }
+
+        return $typeCode;
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getFieldSynopsisElement(DOMDocument $doc, array $allConstInfos): DOMElement
+    {
+        $fieldsynopsisElement = $doc->createElement("fieldsynopsis");
+
+        $this->addModifiersToFieldSynopsis($doc, $fieldsynopsisElement);
+
+        $type = $this->phpDocType ?? $this->type;
+        if ($type) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($type->getTypeForDoc($doc));
+        }
+
+        $varnameElement = $doc->createElement("varname", $this->getFieldSynopsisName());
+        if ($this->link) {
+            $varnameElement->setAttribute("linkend", $this->link);
+        } else {
+            $varnameElement->setAttribute("linkend", $this->getFieldSynopsisDefaultLinkend());
+        }
+
+        $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+        $fieldsynopsisElement->appendChild($varnameElement);
+
+        $valueString = $this->getFieldSynopsisValueString($allConstInfos);
+        if ($valueString) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $initializerElement = $doc->createElement("initializer",  $valueString);
+            $fieldsynopsisElement->appendChild($initializerElement);
+        }
+
+        $fieldsynopsisElement->appendChild(new DOMText("\n    "));
+
+        return $fieldsynopsisElement;
+    }
+
+    protected function addModifiersToFieldSynopsis(DOMDocument $doc, DOMElement $fieldsynopsisElement): void
+    {
+        if ($this->flags & Modifiers::PUBLIC) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "public"));
+        } elseif ($this->flags & Modifiers::PROTECTED) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "protected"));
+        } elseif ($this->flags & Modifiers::PRIVATE) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "private"));
+        }
+    }
+}
+
+class ConstInfo extends VariableLike
+{
+    public /* readonly */ AbstractConstName $name;
+    public /* readonly */ Expr $value;
+    private bool $isDeprecated;
+    private /* readonly */ ?string $valueString;
+    public /* readonly */ ?string $cond;
+    public /* readonly */ ?string $cValue;
+    public /* readonly */ bool $isUndocumentable;
+    private /* readonly */ bool $isFileCacheAllowed;
+
+    /**
+     * @param AttributeInfo[] $attributes
+     */
+    public function __construct(
+        AbstractConstName $name,
+        int $flags,
+        Expr $value,
+        ?string $valueString,
+        ?Type $type,
+        ?Type $phpDocType,
+        bool $isDeprecated,
+        ?string $cond,
+        ?string $cValue,
+        bool $isUndocumentable,
+        ?string $link,
+        ?int $phpVersionIdMinimumCompatibility,
+        array $attributes,
+        ?ExposedDocComment $exposedDocComment,
+        bool $isFileCacheAllowed
+    ) {
+        foreach ($attributes as $attr) {
+            if ($attr->class === "Deprecated") {
+                $isDeprecated = true;
+                break;
+            }
+        }
+
+        $this->name = $name;
+        $this->value = $value;
+        $this->valueString = $valueString;
+        $this->isDeprecated = $isDeprecated;
+        $this->cond = $cond;
+        $this->cValue = $cValue;
+        $this->isUndocumentable = $isUndocumentable;
+        $this->isFileCacheAllowed = $isFileCacheAllowed;
+        parent::__construct($flags, $type, $phpDocType, $link, $phpVersionIdMinimumCompatibility, $attributes, $exposedDocComment);
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getValue(array $allConstInfos): EvaluatedValue
+    {
+        return EvaluatedValue::createFromExpression(
+            $this->value,
+            ($this->phpDocType ?? $this->type)->tryToSimpleType(),
+            $this->cValue,
+            $allConstInfos
+        );
+    }
+
+    protected function getVariableTypeName(): string
+    {
+        return "constant";
+    }
+
+    protected function getFieldSynopsisDefaultLinkend(): string
+    {
+        $className = str_replace(["\\", "_"], ["-", "-"], $this->name->class->toLowerString());
+
+        return "$className.constants." . strtolower(str_replace("_", "-", trim($this->name->getDeclarationName(), "_")));
+    }
+
+    protected function getFieldSynopsisName(): string
+    {
+        return $this->name->__toString();
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    protected function getFieldSynopsisValueString(array $allConstInfos): ?string
+    {
+        $value = EvaluatedValue::createFromExpression($this->value, null, $this->cValue, $allConstInfos);
+        if ($value->isUnknownConstValue) {
+            return null;
+        }
+
+        if ($value->originatingConsts) {
+            return implode("\n", array_map(function (ConstInfo $const) use ($allConstInfos) {
+                return $const->getFieldSynopsisValueString($allConstInfos);
+            }, $value->originatingConsts));
+        }
+
+        return $this->valueString;
+    }
+
+    private function getPredefinedConstantElement(
+        DOMDocument $doc,
+        int $indentationLevel,
+        string $name
+    ): DOMElement {
+        $indentation = str_repeat(" ", $indentationLevel);
+
+        $element = $doc->createElement($name);
+
+        $constantElement = $doc->createElement("constant");
+        $constantElement->textContent = $this->name->__toString();
+
+        $typeElement = ($this->phpDocType ?? $this->type)->getTypeForDoc($doc);
+
+        $element->appendChild(new DOMText("\n$indentation "));
+        $element->appendChild($constantElement);
+        $element->appendChild(new DOMText("\n$indentation ("));
+        $element->appendChild($typeElement);
+        $element->appendChild(new DOMText(")\n$indentation"));
+
+        return $element;
+    }
+
+    public function getPredefinedConstantTerm(DOMDocument $doc, int $indentationLevel): DOMElement
+    {
+        return $this->getPredefinedConstantElement($doc, $indentationLevel, "term");
+    }
+
+    public function getPredefinedConstantEntry(DOMDocument $doc, int $indentationLevel): DOMElement
+    {
+        return $this->getPredefinedConstantElement($doc, $indentationLevel, "entry");
+    }
+
+    public function discardInfoForOldPhpVersions(?int $phpVersionIdMinimumCompatibility): void
+    {
+        $this->type = null;
+        $this->flags &= ~Modifiers::FINAL;
+        $this->isDeprecated = false;
+        $this->attributes = [];
+        $this->phpVersionIdMinimumCompatibility = $phpVersionIdMinimumCompatibility;
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getDeclaration(array $allConstInfos): string
+    {
+        $type = $this->phpDocType ?? $this->type;
+        $simpleType = $type ? $type->tryToSimpleType() : null;
+        if ($simpleType && $simpleType->name === "mixed") {
+            $simpleType = null;
+        }
+
+        $value = EvaluatedValue::createFromExpression($this->value, $simpleType, $this->cValue, $allConstInfos);
+        if ($value->isUnknownConstValue && ($simpleType === null || !$simpleType->isBuiltin)) {
+            throw new Exception("Constant " . $this->name->__toString() . " must have a built-in PHPDoc type as the type couldn't be inferred from its value");
+        }
+
+        // i.e. const NAME = UNKNOWN;, without the annotation
+        if ($value->isUnknownConstValue && $this->cValue === null && $value->expr instanceof Expr\ConstFetch && $value->expr->name->__toString() === "UNKNOWN") {
+            throw new Exception("Constant " . $this->name->__toString() . " must have a @cvalue annotation");
+        }
+
+        // Condition will be added by generateCodeWithConditions()
+
+        if ($this->name instanceof ClassConstName) {
+            $code = $this->getClassConstDeclaration($value, $allConstInfos);
+        } else {
+            $code = $this->getGlobalConstDeclaration($value);
+        }
+        $code .= $this->getValueAssertion($value);
+
+        return $code;
+    }
+
+    private function getGlobalConstDeclaration(EvaluatedValue $value): string
+    {
+        $constName = str_replace('\\', '\\\\', $this->name->__toString());
+        $constValue = $value->value;
+        $cExpr = $value->getCExpr();
+
+        $flags = "CONST_PERSISTENT";
+        if (!$this->isFileCacheAllowed) {
+            $flags .= " | CONST_NO_FILE_CACHE";
+        }
+        if ($this->phpVersionIdMinimumCompatibility !== null && $this->phpVersionIdMinimumCompatibility < 80000) {
+            $flags .= " | CONST_CS";
+        }
+
+        if ($this->isDeprecated) {
+            $flags .= " | CONST_DEPRECATED";
+        }
+
+        $code = "\t";
+        if ($this->attributes !== []) {
+            if ($this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_85_VERSION_ID) {
+                // Registration only returns the constant since PHP 8.5, it's
+                // not worth the bloat to add two different registration blocks
+                // with conditions for the PHP version
+                $constVarName = 'const_' . $constName;
+                $code .= "zend_constant *$constVarName = ";
+            }
+        }
+
+        if ($value->type->isNull()) {
+            return $code . "REGISTER_NULL_CONSTANT(\"$constName\", $flags);\n";
+        }
+
+        if ($value->type->isBool()) {
+            return $code . "REGISTER_BOOL_CONSTANT(\"$constName\", " . ($cExpr ?: ($constValue ? "true" : "false")) . ", $flags);\n";
+        }
+
+        if ($value->type->isInt()) {
+            return $code . "REGISTER_LONG_CONSTANT(\"$constName\", " . ($cExpr ?: (int) $constValue) . ", $flags);\n";
+        }
+
+        if ($value->type->isFloat()) {
+            return $code . "REGISTER_DOUBLE_CONSTANT(\"$constName\", " . ($cExpr ?: (float) $constValue) . ", $flags);\n";
+        }
+
+        if ($value->type->isString()) {
+            return $code . "REGISTER_STRING_CONSTANT(\"$constName\", " . ($cExpr ?: '"' . addslashes($constValue) . '"') . ", $flags);\n";
+        }
+
+        throw new Exception("Unimplemented constant type");
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    private function getClassConstDeclaration(EvaluatedValue $value, array $allConstInfos): string
+    {
+        $constName = $this->name->getDeclarationName();
+
+        // TODO $allConstInfos is unused
+        $zvalCode = $value->initializeZval("const_{$constName}_value");
+
+        $code = "\n" . $zvalCode;
+
+        $code .= "\tzend_string *const_{$constName}_name = zend_string_init_interned(\"$constName\", sizeof(\"$constName\") - 1, true);\n";
+        $nameCode = "const_{$constName}_name";
+
+        if ($this->exposedDocComment) {
+            $commentCode = "const_{$constName}_comment";
+            $escapedCommentInit = $this->exposedDocComment->getInitCode();
+            $code .= "\tzend_string *$commentCode = $escapedCommentInit\n";
+        } else {
+            $commentCode = "NULL";
+        }
+
+        $php83MinimumCompatibility = $this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_83_VERSION_ID;
+
+        if ($this->type && !$php83MinimumCompatibility) {
+            $code .= "#if (PHP_VERSION_ID >= " . PHP_83_VERSION_ID . ")\n";
+        }
+
+        if ($this->type) {
+            $typeCode = $this->getTypeCode($constName, $code);
+
+            if (!empty($this->attributes)) {
+                $template = "\tzend_class_constant *const_" . $this->name->getDeclarationName() . " = ";
+            } else {
+                $template = "\t";
+            }
+            $template .= "zend_declare_typed_class_constant(class_entry, $nameCode, &const_{$constName}_value, %s, $commentCode, $typeCode);\n";
+
+            $code .= $this->getFlagsByPhpVersion()->generateVersionDependentFlagCode(
+                $template,
+                $this->phpVersionIdMinimumCompatibility
+            );
+        }
+
+        if ($this->type && !$php83MinimumCompatibility) {
+            $code .= "#else\n";
+        }
+
+        if (!$this->type || !$php83MinimumCompatibility) {
+            if (!empty($this->attributes)) {
+                $template = "\tzend_class_constant *const_" . $this->name->getDeclarationName() . " = ";
+            } else {
+                $template = "\t";
+            }
+            $template .= "zend_declare_class_constant_ex(class_entry, $nameCode, &const_{$constName}_value, %s, $commentCode);\n";
+            $code .= $this->getFlagsByPhpVersion()->generateVersionDependentFlagCode(
+                $template,
+                $this->phpVersionIdMinimumCompatibility
+            );
+        }
+
+        if ($this->type && !$php83MinimumCompatibility) {
+            $code .= "#endif\n";
+        }
+
+        $code .= "\tzend_string_release_ex(const_{$constName}_name, true);\n";
+
+        return $code;
+    }
+
+    private function getValueAssertion(EvaluatedValue $value): string
+    {
+        if ($value->isUnknownConstValue || $value->originatingConsts || $this->cValue === null) {
+            return "";
+        }
+
+        $cExpr = $value->getCExpr();
+        $constValue = $value->value;
+
+        if ($value->type->isNull()) {
+            return "\tZEND_ASSERT($cExpr == NULL);\n";
+        }
+
+        if ($value->type->isBool()) {
+            $cValue = $constValue ? "true" : "false";
+            return "\tZEND_ASSERT($cExpr == $cValue);\n";
+        }
+
+        if ($value->type->isInt()) {
+            $cValue = (int) $constValue;
+            return "\tZEND_ASSERT($cExpr == $cValue);\n";
+        }
+
+        if ($value->type->isFloat()) {
+            $cValue = (float) $constValue;
+            return "\tZEND_ASSERT($cExpr == $cValue);\n";
+        }
+
+        if ($value->type->isString()) {
+            $cValue = '"' . addslashes($constValue) . '"';
+            return "\tZEND_ASSERT(strcmp($cExpr, $cValue) == 0);\n";
+        }
+
+        throw new Exception("Unimplemented constant type");
+    }
+
+    protected function getFlagsByPhpVersion(): VersionFlags
+    {
+        $flags = parent::getFlagsByPhpVersion();
+
+        // $this->isDeprecated also accounts for any #[\Deprecated] attributes
+        if ($this->isDeprecated) {
+            $flags->addForVersionsAbove("ZEND_ACC_DEPRECATED", PHP_80_VERSION_ID);
+        }
+
+        if ($this->flags & Modifiers::FINAL) {
+            $flags->addForVersionsAbove("ZEND_ACC_FINAL", PHP_81_VERSION_ID);
+        }
+
+        return $flags;
+    }
+
+    protected function addModifiersToFieldSynopsis(DOMDocument $doc, DOMElement $fieldsynopsisElement): void
+    {
+        parent::addModifiersToFieldSynopsis($doc, $fieldsynopsisElement);
+
+        if ($this->flags & Modifiers::FINAL) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "final"));
+        }
+
+        $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+        $fieldsynopsisElement->appendChild($doc->createElement("modifier", "const"));
+    }
+}
+
+class StringBuilder
+{
+
+    // Map possible variable names to the known string constant, see
+    // ZEND_KNOWN_STRINGS
+    private const PHP_80_KNOWN = [
+        "file" => "ZEND_STR_FILE",
+        "line" => "ZEND_STR_LINE",
+        "function" => "ZEND_STR_FUNCTION",
+        "class" => "ZEND_STR_CLASS",
+        "object" => "ZEND_STR_OBJECT",
+        "type" => "ZEND_STR_TYPE",
+        // ZEND_STR_OBJECT_OPERATOR and ZEND_STR_PAAMAYIM_NEKUDOTAYIM are
+        // not valid variable names
+        "args" => "ZEND_STR_ARGS",
+        "unknown" => "ZEND_STR_UNKNOWN",
+        "eval" => "ZEND_STR_EVAL",
+        "include" => "ZEND_STR_INCLUDE",
+        "require" => "ZEND_STR_REQUIRE",
+        "include_once" => "ZEND_STR_INCLUDE_ONCE",
+        "require_once" => "ZEND_STR_REQUIRE_ONCE",
+        "scalar" => "ZEND_STR_SCALAR",
+        "error_reporting" => "ZEND_STR_ERROR_REPORTING",
+        "static" => "ZEND_STR_STATIC",
+        // ZEND_STR_THIS cannot be used since $this cannot be reassigned
+        "value" => "ZEND_STR_VALUE",
+        "key" => "ZEND_STR_KEY",
+        "__invoke" => "ZEND_STR_MAGIC_INVOKE",
+        "previous" => "ZEND_STR_PREVIOUS",
+        "code" => "ZEND_STR_CODE",
+        "message" => "ZEND_STR_MESSAGE",
+        "severity" => "ZEND_STR_SEVERITY",
+        "string" => "ZEND_STR_STRING",
+        "trace" => "ZEND_STR_TRACE",
+        "scheme" => "ZEND_STR_SCHEME",
+        "host" => "ZEND_STR_HOST",
+        "port" => "ZEND_STR_PORT",
+        "user" => "ZEND_STR_USER",
+        "pass" => "ZEND_STR_PASS",
+        "path" => "ZEND_STR_PATH",
+        "query" => "ZEND_STR_QUERY",
+        "fragment" => "ZEND_STR_FRAGMENT",
+        "NULL" => "ZEND_STR_NULL",
+        "boolean" => "ZEND_STR_BOOLEAN",
+        "integer" => "ZEND_STR_INTEGER",
+        "double" => "ZEND_STR_DOUBLE",
+        "array" => "ZEND_STR_ARRAY",
+        "resource" => "ZEND_STR_RESOURCE",
+        // ZEND_STR_CLOSED_RESOURCE has a space in it
+        "name" => "ZEND_STR_NAME",
+        // ZEND_STR_ARGV and ZEND_STR_ARGC are superglobals that wouldn't be
+        // variable names
+        "Array" => "ZEND_STR_ARRAY_CAPITALIZED",
+        "bool" => "ZEND_STR_BOOL",
+        "int" => "ZEND_STR_INT",
+        "float" => "ZEND_STR_FLOAT",
+        "callable" => "ZEND_STR_CALLABLE",
+        "iterable" => "ZEND_STR_ITERABLE",
+        "void" => "ZEND_STR_VOID",
+        "false" => "ZEND_STR_FALSE",
+        "null" => "ZEND_STR_NULL_LOWERCASE",
+        "mixed" => "ZEND_STR_MIXED",
+    ];
+
+    // NEW in 8.1
+    private const PHP_81_KNOWN = [
+        "Unknown" => "ZEND_STR_UNKNOWN_CAPITALIZED",
+        "never" => "ZEND_STR_NEVER",
+        "__sleep" => "ZEND_STR_SLEEP",
+        "__wakeup" => "ZEND_STR_WAKEUP",
+        "cases" => "ZEND_STR_CASES",
+        "from" => "ZEND_STR_FROM",
+        "tryFrom" => "ZEND_STR_TRYFROM",
+        "tryfrom" => "ZEND_STR_TRYFROM_LOWERCASE",
+        // Omit ZEND_STR_AUTOGLOBAL_(SERVER|ENV|REQUEST)
+    ];
+
+    // NEW in 8.2
+    private const PHP_82_KNOWN = [
+        "true" => "ZEND_STR_TRUE",
+        "Traversable" => "ZEND_STR_TRAVERSABLE",
+        "count" => "ZEND_STR_COUNT",
+        "SensitiveParameter" => "ZEND_STR_SENSITIVEPARAMETER",
+    ];
+
+    // Only new string in 8.3 is ZEND_STR_CONST_EXPR_PLACEHOLDER which is
+    // not a valid variable name ("[constant expression]")
+
+    // NEW in 8.4
+    private const PHP_84_KNOWN = [
+        "exit" => "ZEND_STR_EXIT",
+        "Deprecated" => "ZEND_STR_DEPRECATED_CAPITALIZED",
+        "since" => "ZEND_STR_SINCE",
+        "get" => "ZEND_STR_GET",
+        "set" => "ZEND_STR_SET",
+    ];
+
+    // NEW in 8.5
+    private const PHP_85_KNOWN = [
+        "self" => "ZEND_STR_SELF",
+        "parent" => "ZEND_STR_PARENT",
+        "username" => "ZEND_STR_USERNAME",
+        "password" => "ZEND_STR_PASSWORD",
+        "clone" => "ZEND_STR_CLONE",
+        '8.0' => 'ZEND_STR_8_DOT_0',
+        '8.1' => 'ZEND_STR_8_DOT_1',
+        '8.2' => 'ZEND_STR_8_DOT_2',
+        '8.3' => 'ZEND_STR_8_DOT_3',
+        '8.4' => 'ZEND_STR_8_DOT_4',
+        '8.5' => 'ZEND_STR_8_DOT_5',
+    ];
+
+    /**
+     * Get an array of three strings:
+     *   - declaration of zend_string, if needed, or empty otherwise
+     *   - usage of that zend_string, or usage with ZSTR_KNOWN()
+     *   - freeing the zend_string, if needed
+     *
+     * @param string $varName
+     * @param string $strContent
+     * @param ?int $minPHPCompatibility
+     * @param bool $interned
+     * @return string[]
+     */
+    public static function getString(
+        string $varName,
+        string $content,
+        ?int $minPHPCompatibility,
+        bool $interned = false
+    ): array {
+        // Generally strings will not be known
+        $initFn = $interned ? 'zend_string_init_interned' : 'zend_string_init';
+        $result = [
+            "\tzend_string *$varName = $initFn(\"$content\", sizeof(\"$content\") - 1, true);\n",
+            $varName,
+            "\tzend_string_release_ex($varName, true);\n"
+        ];
+        // For attribute values that are not freed
+        if ($varName === '') {
+            $result[0] = "$initFn(\"$content\", sizeof(\"$content\") - 1, true);\n";
+        }
+        // If not set, use the current latest version
+        $allVersions = ALL_PHP_VERSION_IDS;
+        $minPhp = $minPHPCompatibility ?? end($allVersions);
+        if ($minPhp < PHP_80_VERSION_ID) {
+            // No known strings in 7.0
+            return $result;
+        }
+        $include = self::PHP_80_KNOWN;
+        switch ($minPhp) {
+            case PHP_85_VERSION_ID:
+                $include = array_merge($include, self::PHP_85_KNOWN);
+                // Intentional fall through
+
+            case PHP_84_VERSION_ID:
+                $include = array_merge($include, self::PHP_84_KNOWN);
+                // Intentional fall through
+
+            case PHP_83_VERSION_ID:
+            case PHP_82_VERSION_ID:
+                $include = array_merge($include, self::PHP_82_KNOWN);
+                // Intentional fall through
+
+            case PHP_81_VERSION_ID:
+                $include = array_merge($include, self::PHP_81_KNOWN);
+                break;
+        }
+        if (array_key_exists($content, $include)) {
+            $knownStr = $include[$content];
+            return [
+                '',
+                "ZSTR_KNOWN($knownStr)",
+                '',
+            ];
+        }
+        return $result;
+    }
+}
+
+class PropertyInfo extends VariableLike
+{
+    private /* readonly */ int $classFlags;
+    public /* readonly */ PropertyName $name;
+    private /* readonly */ ?Expr $defaultValue;
+    private /* readonly */ ?string $defaultValueString;
+    private /* readonly */ bool $isDocReadonly;
+    private /* readonly */ bool $isVirtual;
+
+    /**
+     * @param AttributeInfo[] $attributes
+     */
+    public function __construct(
+        PropertyName $name,
+        int $classFlags,
+        int $flags,
+        ?Type $type,
+        ?Type $phpDocType,
+        ?Expr $defaultValue,
+        ?string $defaultValueString,
+        bool $isDocReadonly,
+        bool $isVirtual,
+        ?string $link,
+        ?int $phpVersionIdMinimumCompatibility,
+        array $attributes,
+        ?ExposedDocComment $exposedDocComment
+    ) {
+        $this->name = $name;
+        $this->classFlags = $classFlags;
+        $this->defaultValue = $defaultValue;
+        $this->defaultValueString = $defaultValueString;
+        $this->isDocReadonly = $isDocReadonly;
+        $this->isVirtual = $isVirtual;
+        parent::__construct($flags, $type, $phpDocType, $link, $phpVersionIdMinimumCompatibility, $attributes, $exposedDocComment);
+    }
+
+    protected function getVariableTypeName(): string
+    {
+        return "property";
+    }
+
+    protected function getFieldSynopsisDefaultLinkend(): string
+    {
+        $className = str_replace(["\\", "_"], ["-", "-"], $this->name->class->toLowerString());
+
+        return "$className.props." . strtolower(str_replace("_", "-", trim($this->name->getDeclarationName(), "_")));
+    }
+
+    protected function getFieldSynopsisName(): string
+    {
+        return $this->name->getDeclarationName();
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    protected function getFieldSynopsisValueString(array $allConstInfos): ?string
+    {
+        return $this->defaultValueString;
+    }
+
+    public function discardInfoForOldPhpVersions(?int $phpVersionIdMinimumCompatibility): void
+    {
+        $this->type = null;
+        $this->flags &= ~Modifiers::READONLY;
+        $this->attributes = [];
+        $this->phpVersionIdMinimumCompatibility = $phpVersionIdMinimumCompatibility;
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getDeclaration(array $allConstInfos): string
+    {
+        $code = "\n";
+
+        $propertyName = $this->name->getDeclarationName();
+
+        if ($this->defaultValue === null) {
+            $defaultValue = EvaluatedValue::null();
+        } else {
+            $defaultValue = EvaluatedValue::createFromExpression($this->defaultValue, null, null, $allConstInfos);
+            if ($defaultValue->isUnknownConstValue || ($defaultValue->originatingConsts && $defaultValue->getCExpr() === null)) {
+                echo "Skipping code generation for property $this->name, because it has an unknown constant default value\n";
+                return "";
+            }
+        }
+
+        $zvalName = "property_{$propertyName}_default_value";
+        if ($this->defaultValue === null && $this->type !== null) {
+            $code .= "\tzval $zvalName;\n\tZVAL_UNDEF(&$zvalName);\n";
+        } else {
+            $code .= $defaultValue->initializeZval($zvalName);
+        }
+
+        [$stringInit, $nameCode, $stringRelease] = StringBuilder::getString(
+            "property_{$propertyName}_name",
+            $propertyName,
+            $this->phpVersionIdMinimumCompatibility
+        );
+        $code .= $stringInit;
+
+        if ($this->exposedDocComment) {
+            $commentCode = "property_{$propertyName}_comment";
+            $escapedCommentInit = $this->exposedDocComment->getInitCode();
+            $code .= "\tzend_string *$commentCode = $escapedCommentInit\n";
+        } else {
+            $commentCode = "NULL";
+        }
+
+        if (!empty($this->attributes)) {
+            $template = "\tzend_property_info *property_" . $this->name->getDeclarationName() . " = ";
+        } else {
+            $template = "\t";
+        }
+
+        if ($this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_80_VERSION_ID) {
+            $typeCode = $this->getTypeCode($propertyName, $code);
+            $template .= "zend_declare_typed_property(class_entry, $nameCode, &$zvalName, %s, $commentCode, $typeCode);\n";
+        } else {
+            $template .= "zend_declare_property_ex(class_entry, $nameCode, &$zvalName, %s, $commentCode);\n";
+        }
+
+        $code .= $this->getFlagsByPhpVersion()->generateVersionDependentFlagCode(
+            $template,
+            $this->phpVersionIdMinimumCompatibility
+        );
+
+        $code .= $stringRelease;
+
+        return $code;
+    }
+
+    protected function getFlagsByPhpVersion(): VersionFlags
+    {
+        $flags = parent::getFlagsByPhpVersion();
+
+        if ($this->flags & Modifiers::STATIC) {
+            $flags->addForVersionsAbove("ZEND_ACC_STATIC", PHP_70_VERSION_ID);
+        }
+
+        if ($this->flags & Modifiers::FINAL) {
+            $flags->addForVersionsAbove("ZEND_ACC_FINAL", PHP_84_VERSION_ID);
+        }
+
+        if ($this->flags & Modifiers::READONLY) {
+            $flags->addForVersionsAbove("ZEND_ACC_READONLY", PHP_81_VERSION_ID);
+        } elseif ($this->classFlags & Modifiers::READONLY) {
+            $flags->addForVersionsAbove("ZEND_ACC_READONLY", PHP_82_VERSION_ID);
+        }
+
+        if ($this->isVirtual) {
+            $flags->addForVersionsAbove("ZEND_ACC_VIRTUAL", PHP_84_VERSION_ID);
+        }
+
+        return $flags;
+    }
+
+    protected function addModifiersToFieldSynopsis(DOMDocument $doc, DOMElement $fieldsynopsisElement): void
+    {
+        parent::addModifiersToFieldSynopsis($doc, $fieldsynopsisElement);
+
+        if ($this->flags & Modifiers::STATIC) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "static"));
+        }
+
+        if ($this->flags & Modifiers::FINAL) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "final"));
+        }
+
+        if ($this->flags & Modifiers::READONLY || $this->isDocReadonly) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $fieldsynopsisElement->appendChild($doc->createElement("modifier", "readonly"));
+        }
+    }
+}
+
+class EnumCaseInfo
+{
+    private /* readonly */ string $name;
+    private /* readonly */ ?Expr $value;
+
+    public function __construct(string $name, ?Expr $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getDeclaration(array $allConstInfos): string
+    {
+        $escapedName = addslashes($this->name);
+        if ($this->value === null) {
+            $code = "\n\tzend_enum_add_case_cstr(class_entry, \"$escapedName\", NULL);\n";
+        } else {
+            $value = EvaluatedValue::createFromExpression($this->value, null, null, $allConstInfos);
+
+            $zvalName = "enum_case_{$escapedName}_value";
+            $code = "\n" . $value->initializeZval($zvalName);
+            $code .= "\tzend_enum_add_case_cstr(class_entry, \"$escapedName\", &$zvalName);\n";
+        }
+
+        return $code;
+    }
+}
+
+// Instances of AttributeInfo are immutable and do not need to be cloned
+// when held by an object that is cloned
+class AttributeInfo
+{
+    public /* readonly */ string $class;
+    /** @var \PhpParser\Node\Arg[] */
+    private /* readonly */ array $args;
+
+    /** @param \PhpParser\Node\Arg[] $args */
+    public function __construct(string $class, array $args)
+    {
+        $this->class = $class;
+        $this->args = $args;
+    }
+
+    /**
+     * @param array<string, ConstInfo> $allConstInfos
+     * @param array<string, string> &$declaredStrings Map of string content to
+     *   the name of a zend_string already created with that content
+     */
+    public function generateCode(string $invocation, string $nameSuffix, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, array &$declaredStrings = []): string
+    {
+        $escapedAttributeName = strtr($this->class, '\\', '_');
+        [$stringInit, $nameCode, $stringRelease] = StringBuilder::getString(
+            "attribute_name_{$escapedAttributeName}_$nameSuffix",
+            addcslashes($this->class, "\\"),
+            $phpVersionIdMinimumCompatibility,
+            true
+        );
+        $code = "\n";
+        $code .= $stringInit;
+        $code .= "\t" . ($this->args ? "zend_attribute *attribute_{$escapedAttributeName}_$nameSuffix = " : "") . "$invocation, $nameCode, " . count($this->args) . ");\n";
+        $code .= $stringRelease;
+
+        foreach ($this->args as $i => $arg) {
+            $initValue = '';
+            if ($arg->value instanceof Node\Scalar\String_) {
+                $strVal = $arg->value->value;
+                [$strInit, $strUse, $strRelease] = StringBuilder::getString(
+                    'unused',
+                    $strVal,
+                    $phpVersionIdMinimumCompatibility
+                );
+                if ($strInit === '') {
+                    $initValue = "\tZVAL_STR(&attribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].value, $strUse);\n";
+                } elseif (isset($declaredStrings[$strVal])) {
+                    $strUse = $declaredStrings[$strVal];
+                    $initValue = "\tZVAL_STR_COPY(&attribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].value, $strUse);\n";
+                }
+            }
+            if ($initValue === '') {
+                $value = EvaluatedValue::createFromExpression($arg->value, null, null, $allConstInfos);
+                $code .= $value->initializeZval(
+                    "attribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].value",
+                    true,
+                    "attribute_{$escapedAttributeName}_{$nameSuffix}_arg{$i}_str"
+                );
+                if ($arg->value instanceof Node\Scalar\String_) {
+                    $declaredStrings[$arg->value->value] = "attribute_{$escapedAttributeName}_{$nameSuffix}_arg{$i}_str";
+                }
+            } else {
+                $code .= $initValue;
+            }
+            if ($arg->name) {
+                [$stringInit, $nameCode, $stringRelease] = StringBuilder::getString(
+                    "",
+                    $arg->name->name,
+                    $phpVersionIdMinimumCompatibility,
+                    true
+                );
+                if ($stringInit === '') {
+                    $nameCode .= ";\n";
+                } else {
+                    $nameCode = $stringInit;
+                }
+                $code .= "\tattribute_{$escapedAttributeName}_{$nameSuffix}->args[$i].name = $nameCode";
+            }
+        }
+        return $code;
+    }
+
+    /**
+     * @param AttributeGroup[] $attributeGroups
+     * @return AttributeInfo[]
+     */
+    public static function createFromGroups(array $attributeGroups): array
+    {
+        $attributes = [];
+
+        foreach ($attributeGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $attributes[] = new AttributeInfo($attr->name->toString(), $attr->args);
+            }
+        }
+
+        return $attributes;
+    }
+}
+
+class ClassInfo
+{
+    public /* readonly */ Name $name;
+    private int $flags;
+    public string $type;
+    public /* readonly */ ?string $alias;
+    private /* readonly */ ?SimpleType $enumBackingType;
+    private /* readonly */ bool $isDeprecated;
+    private bool $isStrictProperties;
+    /** @var AttributeInfo[] */
+    private array $attributes;
+    private ?ExposedDocComment $exposedDocComment;
+    private bool $isNotSerializable;
+    /** @var Name[] */
+    private /* readonly */ array $extends;
+    /** @var Name[] */
+    private /* readonly */ array $implements;
+    /** @var ConstInfo[] */
+    public /* readonly */ array $constInfos;
+    /** @var PropertyInfo[] */
+    private /* readonly */ array $propertyInfos;
+    /** @var FuncInfo[] */
+    public array $funcInfos;
+    /** @var EnumCaseInfo[] */
+    private /* readonly */ array $enumCaseInfos;
+    public /* readonly */ ?string $cond;
+    public ?int $phpVersionIdMinimumCompatibility;
+    public /* readonly */ bool $isUndocumentable;
+
+    /**
+     * @param AttributeInfo[] $attributes
+     * @param Name[] $extends
+     * @param Name[] $implements
+     * @param ConstInfo[] $constInfos
+     * @param PropertyInfo[] $propertyInfos
+     * @param FuncInfo[] $funcInfos
+     * @param EnumCaseInfo[] $enumCaseInfos
+     */
+    public function __construct(
+        Name $name,
+        int $flags,
+        string $type,
+        ?string $alias,
+        ?SimpleType $enumBackingType,
+        bool $isDeprecated,
+        bool $isStrictProperties,
+        array $attributes,
+        ?ExposedDocComment $exposedDocComment,
+        bool $isNotSerializable,
+        array $extends,
+        array $implements,
+        array $constInfos,
+        array $propertyInfos,
+        array $funcInfos,
+        array $enumCaseInfos,
+        ?string $cond,
+        ?int $minimumPhpVersionIdCompatibility,
+        bool $isUndocumentable
+    ) {
+        $this->name = $name;
+        $this->flags = $flags;
+        $this->type = $type;
+        $this->alias = $alias;
+        $this->enumBackingType = $enumBackingType;
+        $this->isDeprecated = $isDeprecated;
+        $this->isStrictProperties = $isStrictProperties;
+        $this->attributes = $attributes;
+        $this->exposedDocComment = $exposedDocComment;
+        $this->isNotSerializable = $isNotSerializable;
+        $this->extends = $extends;
+        $this->implements = $implements;
+        $this->constInfos = $constInfos;
+        $this->propertyInfos = $propertyInfos;
+        $this->funcInfos = $funcInfos;
+        $this->enumCaseInfos = $enumCaseInfos;
+        $this->cond = $cond;
+        $this->phpVersionIdMinimumCompatibility = $minimumPhpVersionIdCompatibility;
+        $this->isUndocumentable = $isUndocumentable;
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function getRegistration(array $allConstInfos): string
+    {
+        $params = [];
+        foreach ($this->extends as $extends) {
+            $params[] = "zend_class_entry *class_entry_" . implode("_", $extends->getParts());
+        }
+        foreach ($this->implements as $implements) {
+            $params[] = "zend_class_entry *class_entry_" . implode("_", $implements->getParts());
+        }
+
+        $escapedName = implode("_", $this->name->getParts());
+
+        $code = '';
+
+        $php80MinimumCompatibility = $this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_80_VERSION_ID;
+        $php81MinimumCompatibility = $this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_81_VERSION_ID;
+        $php84MinimumCompatibility = $this->phpVersionIdMinimumCompatibility === null || $this->phpVersionIdMinimumCompatibility >= PHP_84_VERSION_ID;
+
+        if ($this->type === "enum" && !$php81MinimumCompatibility) {
+            $code .= "#if (PHP_VERSION_ID >= " . PHP_81_VERSION_ID . ")\n";
+        }
+
+        if ($this->cond) {
+            $code .= "#if {$this->cond}\n";
+        }
+
+        $code .= "static zend_class_entry *register_class_$escapedName(" . (empty($params) ? "void" : implode(", ", $params)) . ")\n";
+
+        $code .= "{\n";
+
+        $flags = $this->getFlagsByPhpVersion();
+
+        $classMethods = ($this->funcInfos === []) ? 'NULL' : "class_{$escapedName}_methods";
+        if ($this->type === "enum") {
+            $name = addslashes((string) $this->name);
+            $backingType = $this->enumBackingType
+                ? $this->enumBackingType->toTypeCode() : "IS_UNDEF";
+            $code .= "\tzend_class_entry *class_entry = zend_register_internal_enum(\"$name\", $backingType, $classMethods);\n";
+            if (!$flags->isEmpty()) {
+                $code .= $this->getFlagsByPhpVersion()->generateVersionDependentFlagCode("\tclass_entry->ce_flags = %s;\n", $this->phpVersionIdMinimumCompatibility);
+            }
+        } else {
+            $code .= "\tzend_class_entry ce, *class_entry;\n\n";
+            if (count($this->name->getParts()) > 1) {
+                $className = $this->name->getLast();
+                $namespace = addslashes((string) $this->name->slice(0, -1));
+
+                $code .= "\tINIT_NS_CLASS_ENTRY(ce, \"$namespace\", \"$className\", $classMethods);\n";
+            } else {
+                $code .= "\tINIT_CLASS_ENTRY(ce, \"$this->name\", $classMethods);\n";
+            }
+
+            if ($this->type === "class" || $this->type === "trait") {
+                if (!$php84MinimumCompatibility) {
+                    $code .= "#if (PHP_VERSION_ID >= " . PHP_84_VERSION_ID . ")\n";
+                }
+
+                $template = "\tclass_entry = zend_register_internal_class_with_flags(&ce, " . (isset($this->extends[0]) ? "class_entry_" . str_replace("\\", "_", $this->extends[0]->toString()) : "NULL") . ", %s);\n";
+                $entries = $flags->generateVersionDependentFlagCode($template, $this->phpVersionIdMinimumCompatibility ? max($this->phpVersionIdMinimumCompatibility, PHP_84_VERSION_ID) : null);
+                if ($entries !== '') {
+                    $code .= $entries;
+                } else {
+                    $code .= sprintf($template, "0");
+                }
+
+                if (!$php84MinimumCompatibility) {
+                    $code .= "#else\n";
+
+                    $code .= "\tclass_entry = zend_register_internal_class_ex(&ce, " . (isset($this->extends[0]) ? "class_entry_" . str_replace("\\", "_", $this->extends[0]->toString()) : "NULL") . ");\n";
+                    if (!$flags->isEmpty()) {
+                        $code .= $flags->generateVersionDependentFlagCode("\tclass_entry->ce_flags |= %s;\n", $this->phpVersionIdMinimumCompatibility);
+                    }
+                    $code .= "#endif\n";
+                }
+            } else {
+                $code .= "\tclass_entry = zend_register_internal_interface(&ce);\n";
+                if (!$flags->isEmpty()) {
+                    $code .= $flags->generateVersionDependentFlagCode("\tclass_entry->ce_flags |= %s;\n", $this->phpVersionIdMinimumCompatibility);
+                }
+            }
+        }
+
+        if ($this->exposedDocComment) {
+            if (!$php84MinimumCompatibility) {
+                $code .= "#if (PHP_VERSION_ID >= " . PHP_84_VERSION_ID . ")\n";
+            }
+
+            $code .= "\tclass_entry->doc_comment = " . $this->exposedDocComment->getInitCode() . "\n";
+
+            if (!$php84MinimumCompatibility) {
+                $code .= "#endif\n";
+            }
+        }
+
+        $implements = array_map(
+            function (Name $item) {
+                return "class_entry_" . implode("_", $item->getParts());
+            },
+            $this->type === "interface" ? $this->extends : $this->implements
+        );
+
+        if (!empty($implements)) {
+            $code .= "\tzend_class_implements(class_entry, " . count($implements) . ", " . implode(", ", $implements) . ");\n";
+        }
+
+        if ($this->alias) {
+            $code .= "\tzend_register_class_alias(\"" . str_replace("\\", "\\\\", $this->alias) . "\", class_entry);\n";
+        }
+
+        $code .= generateCodeWithConditions(
+            $this->constInfos,
+            '',
+            static fn(ConstInfo $const): string => $const->getDeclaration($allConstInfos)
+        );
+
+        foreach ($this->enumCaseInfos as $enumCase) {
+            $code .= $enumCase->getDeclaration($allConstInfos);
+        }
+
+        foreach ($this->propertyInfos as $property) {
+            $code .= $property->getDeclaration($allConstInfos);
+        }
+        // Reusable strings for wrapping conditional PHP 8.0+ code
+        if ($php80MinimumCompatibility) {
+            $php80CondStart = '';
+            $php80CondEnd = '';
+        } else {
+            $php80CondStart = "\n#if (PHP_VERSION_ID >= " . PHP_80_VERSION_ID . ")";
+            $php80CondEnd = "#endif\n";
+        }
+
+        $declaredStrings = [];
+
+        if (!empty($this->attributes)) {
+            $code .= $php80CondStart;
+
+            foreach ($this->attributes as $key => $attribute) {
+                $code .= $attribute->generateCode(
+                    "zend_add_class_attribute(class_entry",
+                    "class_{$escapedName}_$key",
+                    $allConstInfos,
+                    $this->phpVersionIdMinimumCompatibility,
+                    $declaredStrings
+                );
+            }
+
+            $code .= $php80CondEnd;
+        }
+
+        if ($attributeInitializationCode = generateConstantAttributeInitialization($this->constInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $this->cond, $declaredStrings)) {
+            $code .= $php80CondStart;
+            $code .= "\n" . $attributeInitializationCode;
+            $code .= $php80CondEnd;
+        }
+
+        if ($attributeInitializationCode = generatePropertyAttributeInitialization($this->propertyInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $declaredStrings)) {
+            $code .= $php80CondStart;
+            $code .= "\n" . $attributeInitializationCode;
+            $code .= $php80CondEnd;
+        }
+
+        if ($attributeInitializationCode = generateFunctionAttributeInitialization($this->funcInfos, $allConstInfos, $this->phpVersionIdMinimumCompatibility, $this->cond, $declaredStrings)) {
+            $code .= $php80CondStart;
+            $code .= "\n" . $attributeInitializationCode;
+            $code .= $php80CondEnd;
+        }
+
+        $code .= "\n\treturn class_entry;\n";
+
+        $code .= "}\n";
+
+        if ($this->cond) {
+            $code .= "#endif\n";
+        }
+
+        if ($this->type === "enum" && !$php81MinimumCompatibility) {
+            $code .= "#endif\n";
+        }
+
+        return $code;
+    }
+
+    private function getFlagsByPhpVersion(): VersionFlags
+    {
+        $php70Flags = [];
+
+        if ($this->type === "trait") {
+            $php70Flags[] = "ZEND_ACC_TRAIT";
+        }
+
+        if ($this->flags & Modifiers::FINAL) {
+            $php70Flags[] = "ZEND_ACC_FINAL";
+        }
+
+        if ($this->flags & Modifiers::ABSTRACT) {
+            $php70Flags[] = "ZEND_ACC_ABSTRACT";
+        }
+
+        if ($this->isDeprecated) {
+            $php70Flags[] = "ZEND_ACC_DEPRECATED";
+        }
+
+        $flags = new VersionFlags($php70Flags);
+
+        if ($this->isStrictProperties) {
+            $flags->addForVersionsAbove("ZEND_ACC_NO_DYNAMIC_PROPERTIES", PHP_80_VERSION_ID);
+        }
+
+        if ($this->isNotSerializable) {
+            $flags->addForVersionsAbove("ZEND_ACC_NOT_SERIALIZABLE", PHP_81_VERSION_ID);
+        }
+
+        if ($this->flags & Modifiers::READONLY) {
+            $flags->addForVersionsAbove("ZEND_ACC_READONLY_CLASS", PHP_82_VERSION_ID);
+        }
+
+        foreach ($this->attributes as $attr) {
+            if ($attr->class === "AllowDynamicProperties") {
+                $flags->addForVersionsAbove("ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES", PHP_82_VERSION_ID);
+                break;
+            }
+        }
+
+        return $flags;
+    }
+
+    public function discardInfoForOldPhpVersions(?int $phpVersionIdMinimumCompatibility): void
+    {
+        $this->attributes = [];
+        $this->flags &= ~Modifiers::READONLY;
+        $this->exposedDocComment = null;
+        $this->isStrictProperties = false;
+        $this->isNotSerializable = false;
+
+        foreach ($this->propertyInfos as $propertyInfo) {
+            $propertyInfo->discardInfoForOldPhpVersions($phpVersionIdMinimumCompatibility);
+        }
+        $this->phpVersionIdMinimumCompatibility = $phpVersionIdMinimumCompatibility;
+    }
+
+    /**
+     * @param array<string, ClassInfo> $classMap
+     * @param array<string, ConstInfo> $allConstInfos
+     */
+    public function getClassSynopsisDocument(array $classMap, array $allConstInfos): ?string
+    {
+        $doc = new DOMDocument();
+        $doc->formatOutput = true;
+        $classSynopsis = $this->getClassSynopsisElement($doc, $classMap, $allConstInfos);
+        if (!$classSynopsis) {
+            return null;
+        }
+
+        $doc->appendChild($classSynopsis);
+
+        return $doc->saveXML();
+    }
+
+    /**
+     * @param array<string, ClassInfo> $classMap
+     * @param array<string, ConstInfo> $allConstInfos
+     */
+    public function getClassSynopsisElement(DOMDocument $doc, array $classMap, array $allConstInfos): ?DOMElement
+    {
+        $classSynopsis = $doc->createElement("classsynopsis");
+        $classSynopsis->setAttribute("class", $this->type === "interface" ? "interface" : "class");
+
+        $exceptionOverride = $this->type === "class" && $this->isException($classMap) ? "exception" : null;
+        $ooElement = self::createOoElement($doc, $this, $exceptionOverride, true, null, 4);
+        if (!$ooElement) {
+            return null;
+        }
+        $classSynopsis->appendChild(new DOMText("\n    "));
+        $classSynopsis->appendChild($ooElement);
+
+        foreach ($this->extends as $k => $parent) {
+            $parentInfo = $classMap[$parent->toString()] ?? null;
+            if ($parentInfo === null) {
+                throw new Exception("Missing parent class " . $parent->toString());
+            }
+
+            $ooElement = self::createOoElement(
+                $doc,
+                $parentInfo,
+                null,
+                false,
+                $k === 0 ? "extends" : null,
+                4
+            );
+            if (!$ooElement) {
+                return null;
+            }
+
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsis->appendChild($ooElement);
+        }
+
+        foreach ($this->implements as $k => $interface) {
+            $interfaceInfo = $classMap[$interface->toString()] ?? null;
+            if (!$interfaceInfo) {
+                throw new Exception("Missing implemented interface " . $interface->toString());
+            }
+
+            $ooElement = self::createOoElement($doc, $interfaceInfo, null, false, $k === 0 ? "implements" : null, 4);
+            if (!$ooElement) {
+                return null;
+            }
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsis->appendChild($ooElement);
+        }
+
+        /** @var array<string, Name> $parentsWithInheritedConstants */
+        $parentsWithInheritedConstants = [];
+        /** @var array<string, Name> $parentsWithInheritedProperties */
+        $parentsWithInheritedProperties = [];
+        /** @var array<int, array{name: Name, types: int[]}> $parentsWithInheritedMethods */
+        $parentsWithInheritedMethods = [];
+
+        $this->collectInheritedMembers(
+            $parentsWithInheritedConstants,
+            $parentsWithInheritedProperties,
+            $parentsWithInheritedMethods,
+            $this->hasConstructor(),
+            $classMap
+        );
+
+        $this->appendInheritedMemberSectionToClassSynopsis(
+            $doc,
+            $classSynopsis,
+            $parentsWithInheritedConstants,
+            "&Constants;",
+            "&InheritedConstants;"
+        );
+
+        if (!empty($this->constInfos)) {
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "&Constants;");
+            $classSynopsisInfo->setAttribute("role", "comment");
+            $classSynopsis->appendChild($classSynopsisInfo);
+
+            foreach ($this->constInfos as $constInfo) {
+                $classSynopsis->appendChild(new DOMText("\n    "));
+                $fieldSynopsisElement = $constInfo->getFieldSynopsisElement($doc, $allConstInfos);
+                $classSynopsis->appendChild($fieldSynopsisElement);
+            }
+        }
+
+        if (!empty($this->propertyInfos)) {
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "&Properties;");
+            $classSynopsisInfo->setAttribute("role", "comment");
+            $classSynopsis->appendChild($classSynopsisInfo);
+
+            foreach ($this->propertyInfos as $propertyInfo) {
+                $classSynopsis->appendChild(new DOMText("\n    "));
+                $fieldSynopsisElement = $propertyInfo->getFieldSynopsisElement($doc, $allConstInfos);
+                $classSynopsis->appendChild($fieldSynopsisElement);
+            }
+        }
+
+        $this->appendInheritedMemberSectionToClassSynopsis(
+            $doc,
+            $classSynopsis,
+            $parentsWithInheritedProperties,
+            "&Properties;",
+            "&InheritedProperties;"
+        );
+
+        if (!empty($this->funcInfos)) {
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "&Methods;");
+            $classSynopsisInfo->setAttribute("role", "comment");
+            $classSynopsis->appendChild($classSynopsisInfo);
+
+            $classReference = self::getClassSynopsisReference($this->name);
+            $escapedName = addslashes($this->name->__toString());
+
+            if ($this->hasConstructor()) {
+                $classSynopsis->appendChild(new DOMText("\n    "));
+                $includeElement = $this->createIncludeElement(
+                    $doc,
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='$escapedName'])"
+                );
+                $classSynopsis->appendChild($includeElement);
+            }
+
+            if ($this->hasMethods()) {
+                $classSynopsis->appendChild(new DOMText("\n    "));
+                $includeElement = $this->createIncludeElement(
+                    $doc,
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='$escapedName'])"
+                );
+                $classSynopsis->appendChild($includeElement);
+            }
+
+            if ($this->hasDestructor()) {
+                $classSynopsis->appendChild(new DOMText("\n    "));
+                $includeElement = $this->createIncludeElement(
+                    $doc,
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='$escapedName'])"
+                );
+                $classSynopsis->appendChild($includeElement);
+            }
+        }
+
+        if (!empty($parentsWithInheritedMethods)) {
+            $classSynopsis->appendChild(new DOMText("\n\n    "));
+            $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "&InheritedMethods;");
+            $classSynopsisInfo->setAttribute("role", "comment");
+            $classSynopsis->appendChild($classSynopsisInfo);
+
+            foreach ($parentsWithInheritedMethods as $parent) {
+                $parentName = $parent["name"];
+                $parentMethodsynopsisTypes = $parent["types"];
+
+                $parentReference = self::getClassSynopsisReference($parentName);
+                $escapedParentName = addslashes($parentName->__toString());
+
+                foreach ($parentMethodsynopsisTypes as $parentMethodsynopsisType) {
+                    $classSynopsis->appendChild(new DOMText("\n    "));
+                    $includeElement = $this->createIncludeElement(
+                        $doc,
+                        "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$parentReference')/db:refentry/db:refsect1[@role='description']/descendant::db:{$parentMethodsynopsisType}[@role='$escapedParentName'])"
+                    );
+
+                    $classSynopsis->appendChild($includeElement);
+                }
+            }
+        }
+
+        $classSynopsis->appendChild(new DOMText("\n   "));
+
+        return $classSynopsis;
+    }
+
+    private static function createOoElement(
+        DOMDocument $doc,
+        ClassInfo $classInfo,
+        ?string $typeOverride,
+        bool $withModifiers,
+        ?string $modifierOverride,
+        int $indentationLevel
+    ): ?DOMElement {
+        $indentation = str_repeat(" ", $indentationLevel);
+
+        if ($classInfo->type !== "class" && $classInfo->type !== "interface") {
+            echo "Class synopsis generation is not implemented for " . $classInfo->type . "\n";
+            return null;
+        }
+
+        $type = $typeOverride !== null ? $typeOverride : $classInfo->type;
+
+        $ooElement = $doc->createElement("oo$type");
+        $ooElement->appendChild(new DOMText("\n$indentation "));
+        if ($modifierOverride !== null) {
+            $ooElement->appendChild($doc->createElement('modifier', $modifierOverride));
+            $ooElement->appendChild(new DOMText("\n$indentation "));
+        } elseif ($withModifiers) {
+            foreach ($classInfo->attributes as $attribute) {
+                $modifier = $doc->createElement("modifier", "#[\\" . $attribute->class . "]");
+                $modifier->setAttribute("role", "attribute");
+                $ooElement->appendChild($modifier);
+                $ooElement->appendChild(new DOMText("\n$indentation "));
+            }
+
+            if ($classInfo->flags & Modifiers::FINAL) {
+                $ooElement->appendChild($doc->createElement('modifier', 'final'));
+                $ooElement->appendChild(new DOMText("\n$indentation "));
+            }
+            if ($classInfo->flags & Modifiers::ABSTRACT) {
+                $ooElement->appendChild($doc->createElement('modifier', 'abstract'));
+                $ooElement->appendChild(new DOMText("\n$indentation "));
+            }
+            if ($classInfo->flags & Modifiers::READONLY) {
+                $ooElement->appendChild($doc->createElement('modifier', 'readonly'));
+                $ooElement->appendChild(new DOMText("\n$indentation "));
+            }
+        }
+
+        $nameElement = $doc->createElement("{$type}name", $classInfo->name->toString());
+        $ooElement->appendChild($nameElement);
+        $ooElement->appendChild(new DOMText("\n$indentation"));
+
+        return $ooElement;
+    }
+
+    public static function getClassSynopsisFilename(Name $name): string
+    {
+        return strtolower(str_replace("_", "-", implode('-', $name->getParts())));
+    }
+
+    private static function getClassSynopsisReference(Name $name): string
+    {
+        return "class." . self::getClassSynopsisFilename($name);
+    }
+
+    /**
+     * @param array<string, Name> $parentsWithInheritedConstants
+     * @param array<string, Name> $parentsWithInheritedProperties
+     * @param array<string, array{name: Name, types: int[]}> $parentsWithInheritedMethods
+     * @param array<string, ClassInfo> $classMap
+     */
+    private function collectInheritedMembers(
+        array &$parentsWithInheritedConstants,
+        array &$parentsWithInheritedProperties,
+        array &$parentsWithInheritedMethods,
+        bool $hasConstructor,
+        array $classMap
+    ): void {
+        foreach ($this->extends as $parent) {
+            $parentInfo = $classMap[$parent->toString()] ?? null;
+            $parentName = $parent->toString();
+
+            if (!$parentInfo) {
+                throw new Exception("Missing parent class $parentName");
+            }
+
+            if (!empty($parentInfo->constInfos) && !isset($parentsWithInheritedConstants[$parentName])) {
+                $parentsWithInheritedConstants[] = $parent;
+            }
+
+            if (!empty($parentInfo->propertyInfos) && !isset($parentsWithInheritedProperties[$parentName])) {
+                $parentsWithInheritedProperties[$parentName] = $parent;
+            }
+
+            if (!$hasConstructor && $parentInfo->hasNonPrivateConstructor()) {
+                $parentsWithInheritedMethods[$parentName]["name"] = $parent;
+                $parentsWithInheritedMethods[$parentName]["types"][] = "constructorsynopsis";
+            }
+
+            if ($parentInfo->hasMethods()) {
+                $parentsWithInheritedMethods[$parentName]["name"] = $parent;
+                $parentsWithInheritedMethods[$parentName]["types"][] = "methodsynopsis";
+            }
+
+            if ($parentInfo->hasDestructor()) {
+                $parentsWithInheritedMethods[$parentName]["name"] = $parent;
+                $parentsWithInheritedMethods[$parentName]["types"][] = "destructorsynopsis";
+            }
+
+            $parentInfo->collectInheritedMembers(
+                $parentsWithInheritedConstants,
+                $parentsWithInheritedProperties,
+                $parentsWithInheritedMethods,
+                $hasConstructor,
+                $classMap
+            );
+        }
+
+        foreach ($this->implements as $parent) {
+            $parentInfo = $classMap[$parent->toString()] ?? null;
+            if (!$parentInfo) {
+                throw new Exception("Missing parent interface " . $parent->toString());
+            }
+
+            if (!empty($parentInfo->constInfos) && !isset($parentsWithInheritedConstants[$parent->toString()])) {
+                $parentsWithInheritedConstants[$parent->toString()] = $parent;
+            }
+
+            $unusedParentsWithInheritedProperties = [];
+            $unusedParentsWithInheritedMethods = [];
+
+            $parentInfo->collectInheritedMembers(
+                $parentsWithInheritedConstants,
+                $unusedParentsWithInheritedProperties,
+                $unusedParentsWithInheritedMethods,
+                $hasConstructor,
+                $classMap
+            );
+        }
+    }
+
+    /** @param array<string, ClassInfo> $classMap */
+    private function isException(array $classMap): bool
+    {
+        if ($this->name->toString() === "Throwable") {
+            return true;
+        }
+
+        foreach ($this->extends as $parentName) {
+            $parent = $classMap[$parentName->toString()] ?? null;
+            if ($parent === null) {
+                throw new Exception("Missing parent class " . $parentName->toString());
+            }
+
+            if ($parent->isException($classMap)) {
+                return true;
+            }
+        }
+
+        if ($this->type === "class") {
+            foreach ($this->implements as $interfaceName) {
+                $interface = $classMap[$interfaceName->toString()] ?? null;
+                if ($interface === null) {
+                    throw new Exception("Missing implemented interface " . $interfaceName->toString());
+                }
+
+                if ($interface->isException($classMap)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function hasConstructor(): bool
+    {
+        foreach ($this->funcInfos as $funcInfo) {
+            if ($funcInfo->name->isConstructor()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasNonPrivateConstructor(): bool
+    {
+        foreach ($this->funcInfos as $funcInfo) {
+            if ($funcInfo->name->isConstructor() && !($funcInfo->flags & Modifiers::PRIVATE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasDestructor(): bool
+    {
+        foreach ($this->funcInfos as $funcInfo) {
+            if ($funcInfo->name->isDestructor()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasMethods(): bool
+    {
+        foreach ($this->funcInfos as $funcInfo) {
+            if (!$funcInfo->name->isConstructor() && !$funcInfo->name->isDestructor()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function createIncludeElement(DOMDocument $doc, string $query): DOMElement
+    {
+        $includeElement = $doc->createElement("xi:include");
+        $attr = $doc->createAttribute("xpointer");
+        $attr->value = $query;
+        $includeElement->appendChild($attr);
+        $fallbackElement = $doc->createElement("xi:fallback");
+        $includeElement->appendChild(new DOMText("\n     "));
+        $includeElement->appendChild($fallbackElement);
+        $includeElement->appendChild(new DOMText("\n    "));
+
+        return $includeElement;
+    }
+
+    public function __clone()
+    {
+        foreach ($this->constInfos as $key => $constInfo) {
+            $this->constInfos[$key] = clone $constInfo;
+        }
+
+        foreach ($this->propertyInfos as $key => $propertyInfo) {
+            $this->propertyInfos[$key] = clone $propertyInfo;
+        }
+
+        foreach ($this->funcInfos as $key => $funcInfo) {
+            $this->funcInfos[$key] = clone $funcInfo;
+        }
+    }
+
+    /**
+     * @param Name[] $parents
+     */
+    private function appendInheritedMemberSectionToClassSynopsis(DOMDocument $doc, DOMElement $classSynopsis, array $parents, string $label, string $inheritedLabel): void
+    {
+        if (empty($parents)) {
+            return;
+        }
+
+        $classSynopsis->appendChild(new DOMText("\n\n    "));
+        $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "$inheritedLabel");
+        $classSynopsisInfo->setAttribute("role", "comment");
+        $classSynopsis->appendChild($classSynopsisInfo);
+
+        foreach ($parents as $parent) {
+            $classSynopsis->appendChild(new DOMText("\n    "));
+            $parentReference = self::getClassSynopsisReference($parent);
+
+            $includeElement = $this->createIncludeElement(
+                $doc,
+                "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$parentReference')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='$label']]))"
+            );
+            $classSynopsis->appendChild($includeElement);
+        }
+    }
+}
+
+class FileInfo
+{
+    /** @var string[] */
+    public array $dependencies = [];
+    /** @var ConstInfo[] */
+    public array $constInfos = [];
+    /** @var FuncInfo[] */
+    public array $funcInfos = [];
+    /** @var ClassInfo[] */
+    public array $classInfos = [];
+    public bool $generateFunctionEntries = false;
+    public string $declarationPrefix = "";
+    public bool $generateClassEntries = false;
+    private bool $isUndocumentable = false;
+    private bool $legacyArginfoGeneration = false;
+    private ?int $minimumPhpVersionIdCompatibility = null;
+
+    /** @param array<int, DocCommentTag> $fileTags */
+    public function __construct(array $fileTags)
+    {
+        foreach ($fileTags as $tag) {
+            if ($tag->name === 'generate-function-entries') {
+                $this->generateFunctionEntries = true;
+                $this->declarationPrefix = $tag->value ? $tag->value . " " : "";
+            } else if ($tag->name === 'generate-legacy-arginfo') {
+                if ($tag->value && !in_array((int) $tag->value, ALL_PHP_VERSION_IDS, true)) {
+                    throw new Exception(
+                        "Legacy PHP version must be one of: \"" . PHP_70_VERSION_ID . "\" (PHP 7.0), \"" . PHP_80_VERSION_ID . "\" (PHP 8.0), " .
+                            "\"" . PHP_81_VERSION_ID . "\" (PHP 8.1), \"" . PHP_82_VERSION_ID . "\" (PHP 8.2), \"" . PHP_83_VERSION_ID . "\" (PHP 8.3), " .
+                            "\"" . PHP_84_VERSION_ID . "\" (PHP 8.4), \"" . PHP_85_VERSION_ID . "\" (PHP 8.5), \"" . $tag->value . "\" provided"
+                    );
+                }
+
+                $this->minimumPhpVersionIdCompatibility = ($tag->value ? (int) $tag->value : PHP_70_VERSION_ID);
+            } else if ($tag->name === 'generate-class-entries') {
+                $this->generateClassEntries = true;
+                $this->declarationPrefix = $tag->value ? $tag->value . " " : "";
+            } else if ($tag->name === 'undocumentable') {
+                $this->isUndocumentable = true;
+            }
+        }
+
+        // Generating class entries require generating function/method entries
+        if ($this->generateClassEntries && !$this->generateFunctionEntries) {
+            $this->generateFunctionEntries = true;
+        }
+    }
+
+    /**
+     * @return iterable<FuncInfo>
+     */
+    public function getAllFuncInfos(): iterable
+    {
+        yield from $this->funcInfos;
+        foreach ($this->classInfos as $classInfo) {
+            yield from $classInfo->funcInfos;
+        }
+    }
+
+    /** @return array<string, ConstInfo> */
+    public function getAllConstInfos(): array
+    {
+        $result = [];
+
+        foreach ($this->constInfos as $constInfo) {
+            $result[$constInfo->name->__toString()] = $constInfo;
+        }
+
+        foreach ($this->classInfos as $classInfo) {
+            foreach ($classInfo->constInfos as $constInfo) {
+                $result[$constInfo->name->__toString()] = $constInfo;
+            }
+        }
+
+        return $result;
+    }
+
+    public function __clone()
+    {
+        foreach ($this->constInfos as $key => $constInfo) {
+            $this->constInfos[$key] = clone $constInfo;
+        }
+
+        foreach ($this->funcInfos as $key => $funcInfo) {
+            $this->funcInfos[$key] = clone $funcInfo;
+        }
+
+        foreach ($this->classInfos as $key => $classInfo) {
+            $this->classInfos[$key] = clone $classInfo;
+        }
+    }
+
+    public function getMinimumPhpVersionIdCompatibility(): ?int
+    {
+        // Non-legacy arginfo files are always PHP 8.0+ compatible
+        if (
+            !$this->legacyArginfoGeneration &&
+            $this->minimumPhpVersionIdCompatibility !== null &&
+            $this->minimumPhpVersionIdCompatibility < PHP_80_VERSION_ID
+        ) {
+            return PHP_80_VERSION_ID;
+        }
+
+        return $this->minimumPhpVersionIdCompatibility;
+    }
+
+    public function shouldGenerateLegacyArginfo(): bool
+    {
+        return $this->minimumPhpVersionIdCompatibility !== null && $this->minimumPhpVersionIdCompatibility < PHP_80_VERSION_ID;
+    }
+
+    public function getLegacyVersion(): FileInfo
+    {
+        $legacyFileInfo = clone $this;
+        $legacyFileInfo->legacyArginfoGeneration = true;
+        $phpVersionIdMinimumCompatibility = $legacyFileInfo->getMinimumPhpVersionIdCompatibility();
+
+        foreach ($legacyFileInfo->getAllFuncInfos() as $funcInfo) {
+            $funcInfo->discardInfoForOldPhpVersions($phpVersionIdMinimumCompatibility);
+        }
+        foreach ($legacyFileInfo->classInfos as $classInfo) {
+            $classInfo->discardInfoForOldPhpVersions($phpVersionIdMinimumCompatibility);
+        }
+        foreach ($legacyFileInfo->getAllConstInfos() as $constInfo) {
+            $constInfo->discardInfoForOldPhpVersions($phpVersionIdMinimumCompatibility);
+        }
+        return $legacyFileInfo;
+    }
+
+    public static function parseStubFile(string $code): FileInfo
+    {
+        $parser = new PhpParser\Parser\Php7(new PhpParser\Lexer\Emulative());
+        $nodeTraverser = new PhpParser\NodeTraverser;
+        $nodeTraverser->addVisitor(new PhpParser\NodeVisitor\NameResolver);
+        $prettyPrinter = new class extends Standard {
+            protected function pName_FullyQualified(Name\FullyQualified $node): string
+            {
+                return implode('\\', $node->getParts());
+            }
+        };
+
+        $stmts = $parser->parse($code);
+        $nodeTraverser->traverse($stmts);
+
+        $fileTags = DocCommentTag::parseDocComments(self::getFileDocComments($stmts));
+        $fileInfo = new FileInfo($fileTags);
+
+        $fileInfo->handleStatements($stmts, $prettyPrinter);
+        return $fileInfo;
+    }
+
+    /** @return DocComment[] */
+    private static function getFileDocComments(array $stmts): array
+    {
+        if (empty($stmts)) {
+            return [];
+        }
+
+        return array_filter(
+            $stmts[0]->getComments(),
+            static fn($comment): bool => $comment instanceof DocComment
+        );
+    }
+
+    private function handleStatements(array $stmts, PrettyPrinterAbstract $prettyPrinter): void
+    {
+        $conds = [];
+        foreach ($stmts as $stmt) {
+            $cond = self::handlePreprocessorConditions($conds, $stmt);
+
+            if ($stmt instanceof Stmt\Nop) {
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Namespace_) {
+                $this->handleStatements($stmt->stmts, $prettyPrinter);
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Const_) {
+                foreach ($stmt->consts as $const) {
+                    $this->constInfos[] = parseConstLike(
+                        $prettyPrinter,
+                        new ConstName($const->namespacedName, $const->name->toString()),
+                        $const,
+                        0,
+                        null,
+                        $stmt->getComments(),
+                        $cond,
+                        $this->isUndocumentable,
+                        $this->getMinimumPhpVersionIdCompatibility(),
+                        AttributeInfo::createFromGroups($stmt->attrGroups)
+                    );
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Function_) {
+                $this->funcInfos[] = parseFunctionLike(
+                    $prettyPrinter,
+                    new FunctionName($stmt->namespacedName),
+                    0,
+                    0,
+                    $stmt,
+                    $cond,
+                    $this->isUndocumentable,
+                    $this->getMinimumPhpVersionIdCompatibility()
+                );
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\ClassLike) {
+                $className = $stmt->namespacedName;
+                $constInfos = [];
+                $propertyInfos = [];
+                $methodInfos = [];
+                $enumCaseInfos = [];
+                foreach ($stmt->stmts as $classStmt) {
+                    $cond = self::handlePreprocessorConditions($conds, $classStmt);
+                    if ($classStmt instanceof Stmt\Nop) {
+                        continue;
+                    }
+
+                    $classFlags = $stmt instanceof Class_ ? $stmt->flags : 0;
+                    $abstractFlag = $stmt instanceof Stmt\Interface_ ? Modifiers::ABSTRACT : 0;
+
+                    if ($classStmt instanceof Stmt\ClassConst) {
+                        foreach ($classStmt->consts as $const) {
+                            $constInfos[] = parseConstLike(
+                                $prettyPrinter,
+                                new ClassConstName($className, $const->name->toString()),
+                                $const,
+                                $classStmt->flags,
+                                $classStmt->type,
+                                $classStmt->getComments(),
+                                $cond,
+                                $this->isUndocumentable,
+                                $this->getMinimumPhpVersionIdCompatibility(),
+                                AttributeInfo::createFromGroups($classStmt->attrGroups)
+                            );
+                        }
+                    } else if ($classStmt instanceof Stmt\Property) {
+                        if (!($classStmt->flags & Class_::VISIBILITY_MODIFIER_MASK)) {
+                            throw new Exception("Visibility modifier is required");
+                        }
+                        foreach ($classStmt->props as $property) {
+                            $propertyInfos[] = parseProperty(
+                                $className,
+                                $classFlags,
+                                $classStmt->flags,
+                                $property,
+                                $classStmt->type,
+                                $classStmt->getComments(),
+                                $prettyPrinter,
+                                $this->getMinimumPhpVersionIdCompatibility(),
+                                AttributeInfo::createFromGroups($classStmt->attrGroups)
+                            );
+                        }
+                    } else if ($classStmt instanceof Stmt\ClassMethod) {
+                        if (!($classStmt->flags & Class_::VISIBILITY_MODIFIER_MASK)) {
+                            throw new Exception("Visibility modifier is required");
+                        }
+                        $methodInfos[] = parseFunctionLike(
+                            $prettyPrinter,
+                            new MethodName($className, $classStmt->name->toString()),
+                            $classFlags,
+                            $classStmt->flags | $abstractFlag,
+                            $classStmt,
+                            $cond,
+                            $this->isUndocumentable,
+                            $this->getMinimumPhpVersionIdCompatibility()
+                        );
+                    } else if ($classStmt instanceof Stmt\EnumCase) {
+                        $enumCaseInfos[] = new EnumCaseInfo(
+                            $classStmt->name->toString(),
+                            $classStmt->expr
+                        );
+                    } else {
+                        throw new Exception("Not implemented {$classStmt->getType()}");
+                    }
+                }
+
+                $this->classInfos[] = parseClass(
+                    $className,
+                    $stmt,
+                    $constInfos,
+                    $propertyInfos,
+                    $methodInfos,
+                    $enumCaseInfos,
+                    $cond,
+                    $this->getMinimumPhpVersionIdCompatibility(),
+                    $this->isUndocumentable
+                );
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Expression) {
+                $expr = $stmt->expr;
+                if ($expr instanceof Expr\Include_) {
+                    $this->dependencies[] = (string)EvaluatedValue::createFromExpression($expr->expr, null, null, [])->value;
+                    continue;
+                }
+            }
+
+            throw new Exception("Unexpected node {$stmt->getType()}");
+        }
+        if (!empty($conds)) {
+            throw new Exception("Unterminated preprocessor conditions");
+        }
+    }
+
+    private static function handlePreprocessorConditions(array &$conds, Stmt $stmt): ?string
+    {
+        foreach ($stmt->getComments() as $comment) {
+            $text = trim($comment->getText());
+            if (preg_match('/^#\s*if\s+(.+)$/', $text, $matches)) {
+                $conds[] = $matches[1];
+            } else if (preg_match('/^#\s*ifdef\s+(.+)$/', $text, $matches)) {
+                $conds[] = "defined($matches[1])";
+            } else if (preg_match('/^#\s*ifndef\s+(.+)$/', $text, $matches)) {
+                $conds[] = "!defined($matches[1])";
+            } else if (preg_match('/^#\s*else$/', $text)) {
+                if (empty($conds)) {
+                    throw new Exception("Encountered else without corresponding #if");
+                }
+                $cond = array_pop($conds);
+                $conds[] = "!($cond)";
+            } else if (preg_match('/^#\s*endif$/', $text)) {
+                if (empty($conds)) {
+                    throw new Exception("Encountered #endif without corresponding #if");
+                }
+                array_pop($conds);
+            } else if ($text[0] === '#') {
+                throw new Exception("Unrecognized preprocessor directive \"$text\"");
+            }
+        }
+
+        return empty($conds) ? null : implode(' && ', $conds);
+    }
+
+    /** @param array<string, ConstInfo> $allConstInfos */
+    public function generateClassEntryCode(array $allConstInfos): string
+    {
+        $code = "";
+
+        foreach ($this->classInfos as $class) {
+            $code .= "\n" . $class->getRegistration($allConstInfos);
+        }
+
+        return $code;
+    }
+}
+
+class DocCommentTag
+{
+    public /* readonly */ string $name;
+    public /* readonly */ ?string $value;
+
+    public function __construct(string $name, ?string $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        if ($this->value === null) {
+            throw new Exception("@$this->name does not have a value");
+        }
+
+        return $this->value;
+    }
+
+    public function getType(): string
+    {
+        $value = $this->getValue();
+
+        $matches = [];
+
+        if ($this->name === "param") {
+            preg_match('/^\s*([\w\|\\\\\[\]<>, ]+)\s*(?:[{(]|\$\w+).*$/', $value, $matches);
+        } elseif ($this->name === "return" || $this->name === "var") {
+            preg_match('/^\s*([\w\|\\\\\[\]<>, ]+)/', $value, $matches);
+        }
+
+        if (!isset($matches[1])) {
+            throw new Exception("@$this->name doesn't contain a type or has an invalid format \"$value\"");
+        }
+
+        return trim($matches[1]);
+    }
+
+    public function getVariableName(): string
+    {
+        $value = $this->value;
+        if ($value === null || strlen($value) === 0) {
+            throw new Exception("@$this->name doesn't have any value");
+        }
+
+        $matches = [];
+
+        if ($this->name === "param") {
+            // Allow for parsing extended types like callable(string):mixed in docblocks
+            preg_match('/^\s*(?<type>[\w\|\\\\]+(?<parens>\((?<inparens>(?:(?&parens)|[^(){}[\]<>]*+))++\)|\{(?&inparens)\}|\[(?&inparens)\]|<(?&inparens)>)*+(?::(?&type))?)\s*\$(?<name>\w+).*$/', $value, $matches);
+        } elseif ($this->name === "prefer-ref") {
+            preg_match('/^\s*\$(?<name>\w+).*$/', $value, $matches);
+        }
+
+        if (!isset($matches["name"])) {
+            throw new Exception("@$this->name doesn't contain a variable name or has an invalid format \"$value\"");
+        }
+
+        return $matches["name"];
+    }
+
+    /** @return DocCommentTag[] */
+    public static function parseDocComments(array $comments): array
+    {
+        $tags = [];
+        foreach ($comments as $comment) {
+            if (!($comment instanceof DocComment)) {
+                continue;
+            }
+            $commentText = substr($comment->getText(), 2, -2);
+            foreach (explode("\n", $commentText) as $commentLine) {
+                $regex = '/^\*\s*@([a-z-]+)(?:\s+(.+))?$/';
+                if (preg_match($regex, trim($commentLine), $matches)) {
+                    $tags[] = new DocCommentTag($matches[1], $matches[2] ?? null);
+                }
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @param DocCommentTag[] $tags
+     * @return array<string, ?string> Mapping tag names to the value (or null),
+     *   if a tag is present multiple times the last value is used
+     */
+    public static function makeTagMap(array $tags): array
+    {
+        $map = [];
+        foreach ($tags as $tag) {
+            $map[$tag->name] = $tag->value;
+        }
+        return $map;
+    }
+}
+
+// Instances of ExposedDocComment are immutable and do not need to be cloned
+// when held by an object that is cloned
+class ExposedDocComment
+{
+    private /* readonly */ string $docComment;
+
+    public function __construct(string $docComment)
+    {
+        $this->docComment = $docComment;
+    }
+
+    public function escape(): string
+    {
+        return str_replace("\n", '\n', addslashes($this->docComment));
+    }
+
+    public function getInitCode(): string
+    {
+        return "zend_string_init_interned(\"" . $this->escape() . "\", " . strlen($this->docComment) . ", 1);";
+    }
+
+    /** @param array<int, DocComment> $comments */
+    public static function extractExposedComment(array $comments): ?ExposedDocComment
+    {
+        $exposedDocComment = null;
+
+        foreach ($comments as $comment) {
+            $text = $comment->getText();
+            $matches = [];
+            $pattern = "#^(\s*\/\*\*)(\s*@genstubs-expose-comment-block)(\s*)$#m";
+
+            if (preg_match($pattern, $text, $matches) !== 1) {
+                continue;
+            }
+
+            if ($exposedDocComment !== null) {
+                throw new Exception("Only one PHPDoc comment block can be exposed");
+            }
+
+            $exposedDocComment = preg_replace($pattern, '$1$3', $text);
+        }
+
+        return $exposedDocComment ? new ExposedDocComment($exposedDocComment) : null;
+    }
+}
+
+// Instances of FramelessFunctionInfo are immutable and do not need to be cloned
+// when held by an object that is cloned
+class FramelessFunctionInfo
+{
+    public /* readonly */ int $arity;
+
+    public function __construct(string $json)
+    {
+        // FIXME: Should have some validation
+        $json = json_decode($json, true);
+
+        $this->arity = $json["arity"];
+    }
+}
+
+function parseFunctionLike(
+    PrettyPrinterAbstract $prettyPrinter,
+    FunctionOrMethodName $name,
+    int $classFlags,
+    int $flags,
+    Node\FunctionLike $func,
+    ?string $cond,
+    bool $isUndocumentable,
+    ?int $minimumPhpVersionIdCompatibility
+): FuncInfo {
+    try {
+        $comments = $func->getComments();
+        $paramMeta = [];
+        $aliasType = null;
+        $alias = null;
+        $isDeprecated = false;
+        $supportsCompileTimeEval = false;
+        $verify = true;
+        $docReturnType = null;
+        $tentativeReturnType = false;
+        $docParamTypes = [];
+        $refcount = null;
+        $framelessFunctionInfos = [];
+
+        if ($comments) {
+            $tags = DocCommentTag::parseDocComments($comments);
+            $tagMap = DocCommentTag::makeTagMap($tags);
+
+            $isDeprecated = array_key_exists('deprecated', $tagMap);
+            $verify = !array_key_exists('no-verify', $tagMap);
+            $tentativeReturnType = array_key_exists('tentative-return-type', $tagMap);
+            $supportsCompileTimeEval = array_key_exists('compile-time-eval', $tagMap);
+            $isUndocumentable = $isUndocumentable || array_key_exists('undocumentable', $tagMap);
+
+            foreach ($tags as $tag) {
+                switch ($tag->name) {
+                    case 'alias':
+                    case 'implementation-alias':
+                        $aliasType = $tag->name;
+                        $aliasParts = explode("::", $tag->getValue());
+                        if (count($aliasParts) === 1) {
+                            $alias = new FunctionName(new Name($aliasParts[0]));
+                        } else {
+                            $alias = new MethodName(new Name($aliasParts[0]), $aliasParts[1]);
+                        }
+                        break;
+
+                    case 'return':
+                        $docReturnType = $tag->getType();
+                        break;
+
+                    case 'param':
+                        $docParamTypes[$tag->getVariableName()] = $tag->getType();
+                        break;
+
+                    case 'refcount':
+                        $refcount = $tag->getValue();
+                        break;
+
+                    case 'prefer-ref':
+                        $varName = $tag->getVariableName();
+                        if (!isset($paramMeta[$varName])) {
+                            $paramMeta[$varName] = [];
+                        }
+                        $paramMeta[$varName][$tag->name] = true;
+                        break;
+
+                    case 'frameless-function':
+                        $framelessFunctionInfos[] = new FramelessFunctionInfo($tag->getValue());
+                        break;
+                }
+            }
+        }
+
+        $varNameSet = [];
+        $args = [];
+        $numRequiredArgs = 0;
+        $foundVariadic = false;
+        foreach ($func->getParams() as $i => $param) {
+            if ($param->isPromoted()) {
+                throw new Exception("Promoted properties are not supported");
+            }
+
+            $varName = $param->var->name;
+            $preferRef = !empty($paramMeta[$varName]['prefer-ref']);
+            unset($paramMeta[$varName]);
+
+            if (isset($varNameSet[$varName])) {
+                throw new Exception("Duplicate parameter name $varName");
+            }
+            $varNameSet[$varName] = true;
+
+            if ($preferRef) {
+                $sendBy = ArgInfo::SEND_PREFER_REF;
+            } else if ($param->byRef) {
+                $sendBy = ArgInfo::SEND_BY_REF;
+            } else {
+                $sendBy = ArgInfo::SEND_BY_VAL;
+            }
+
+            if ($foundVariadic) {
+                throw new Exception("Only the last parameter can be variadic");
+            }
+
+            $type = $param->type ? Type::fromNode($param->type) : null;
+            if ($type === null && !isset($docParamTypes[$varName])) {
+                throw new Exception("Missing parameter type");
+            }
+
+            if (
+                $param->default instanceof Expr\ConstFetch &&
+                $param->default->name->toLowerString() === "null" &&
+                $type && !$type->isNullable()
+            ) {
+                $simpleType = $type->tryToSimpleType();
+                if ($simpleType === null || !$simpleType->isMixed()) {
+                    throw new Exception("Parameter $varName has null default, but is not nullable");
+                }
+            }
+
+            if ($param->default instanceof Expr\ClassConstFetch && $param->default->class->toLowerString() === "self") {
+                throw new Exception('The exact class name must be used instead of "self"');
+            }
+
+            $foundVariadic = $param->variadic;
+
+            $args[] = new ArgInfo(
+                $varName,
+                $sendBy,
+                $param->variadic,
+                $type,
+                isset($docParamTypes[$varName]) ? Type::fromString($docParamTypes[$varName]) : null,
+                $param->default ? $prettyPrinter->prettyPrintExpr($param->default) : null,
+                AttributeInfo::createFromGroups($param->attrGroups)
+            );
+            if (!$param->default && !$param->variadic) {
+                $numRequiredArgs = $i + 1;
+            }
+        }
+
+        foreach (array_keys($paramMeta) as $var) {
+            throw new Exception("Found metadata for invalid param $var");
+        }
+
+        $returnType = $func->getReturnType();
+        if ($returnType === null && $docReturnType === null && !$name->isConstructor() && !$name->isDestructor()) {
+            throw new Exception("Missing return type");
+        }
+
+        $return = new ReturnInfo(
+            $func->returnsByRef(),
+            $returnType ? Type::fromNode($returnType) : null,
+            $docReturnType ? Type::fromString($docReturnType) : null,
+            $tentativeReturnType,
+            $refcount
+        );
+
+        return new FuncInfo(
+            $name,
+            $classFlags,
+            $flags,
+            $aliasType,
+            $alias,
+            $isDeprecated,
+            $supportsCompileTimeEval,
+            $verify,
+            $args,
+            $return,
+            $numRequiredArgs,
+            $cond,
+            $isUndocumentable,
+            $minimumPhpVersionIdCompatibility,
+            AttributeInfo::createFromGroups($func->attrGroups),
+            $framelessFunctionInfos,
+            ExposedDocComment::extractExposedComment($comments)
+        );
+    } catch (Exception $e) {
+        throw new Exception($name . "(): " . $e->getMessage());
+    }
+}
+
+/**
+ * @param array<int, array<int, AttributeGroup> $attributes
+ */
+function parseConstLike(
+    PrettyPrinterAbstract $prettyPrinter,
+    AbstractConstName $name,
+    Node\Const_ $const,
+    int $flags,
+    ?Node $type,
+    array $comments,
+    ?string $cond,
+    bool $isUndocumentable,
+    ?int $phpVersionIdMinimumCompatibility,
+    array $attributes
+): ConstInfo {
+    $phpDocType = null;
+
+    $tags = DocCommentTag::parseDocComments($comments);
+    $tagMap = DocCommentTag::makeTagMap($tags);
+
+    $deprecated = array_key_exists('deprecated', $tagMap);
+    $isUndocumentable = $isUndocumentable || array_key_exists('undocumentable', $tagMap);
+    $isFileCacheAllowed = !array_key_exists('no-file-cache', $tagMap);
+    $cValue = $tagMap['cvalue'] ?? null;
+    $link = $tagMap['link'] ?? null;
+
+    foreach ($tags as $tag) {
+        if ($tag->name === 'var') {
+            $phpDocType = $tag->getType();
+        }
+    }
+
+    if ($type === null && $phpDocType === null) {
+        if ($const->value instanceof Node\Scalar\Float_) {
+            $phpDocType = 'float';
+        } elseif (
+            $const->value instanceof Node\Scalar\Int_
+            || ($const->value instanceof Expr\UnaryMinus
+                && $const->value->expr instanceof Node\Scalar\Int_
+            )
+        ) {
+            $phpDocType = 'int';
+        } elseif ($const->value instanceof Node\Scalar\String_) {
+            $phpDocType = 'string';
+        } elseif (
+            $const->value instanceof Expr\ConstFetch
+            && $const->value->name instanceof Node\Name\FullyQualified
+            && (
+                $const->value->name->name === 'false'
+                || $const->value->name->name === 'true'
+            )
+        ) {
+            $phpDocType = 'bool';
+        } elseif (
+            $const->value instanceof Expr\ConstFetch
+            && $const->value->name instanceof Node\Name\FullyQualified
+            && $const->value->name->name === 'null'
+        ) {
+            $phpDocType = 'null';
+        } else {
+            throw new Exception("Missing type for constant " . $name->__toString());
+        }
+    }
+
+    $constType = $type ? Type::fromNode($type) : null;
+    $constPhpDocType = $phpDocType ? Type::fromString($phpDocType) : null;
+
+    if (
+        $const->value instanceof Expr\ConstFetch &&
+        $const->value->name->toLowerString() === "null" &&
+        $constType && !$constType->isNullable()
+    ) {
+        $simpleType = $constType->tryToSimpleType();
+        if ($simpleType === null || !$simpleType->isMixed()) {
+            throw new Exception("Constant " . $name->__toString() . " has null value, but is not nullable");
+        }
+    }
+
+    return new ConstInfo(
+        $name,
+        $flags,
+        $const->value,
+        $prettyPrinter->prettyPrintExpr($const->value),
+        $constType,
+        $constPhpDocType,
+        $deprecated,
+        $cond,
+        $cValue,
+        $isUndocumentable,
+        $link,
+        $phpVersionIdMinimumCompatibility,
+        $attributes,
+        ExposedDocComment::extractExposedComment($comments),
+        $isFileCacheAllowed
+    );
+}
+
+/**
+ * @param array<int, array<int, AttributeGroup> $attributes
+ */
+function parseProperty(
+    Name $class,
+    int $classFlags,
+    int $flags,
+    Stmt\PropertyProperty $property,
+    ?Node $type,
+    array $comments,
+    PrettyPrinterAbstract $prettyPrinter,
+    ?int $phpVersionIdMinimumCompatibility,
+    array $attributes
+): PropertyInfo {
+    $phpDocType = null;
+
+    $tags = DocCommentTag::parseDocComments($comments);
+    $tagMap = DocCommentTag::makeTagMap($tags);
+
+    $isDocReadonly = array_key_exists('readonly', $tagMap);
+    $link = $tagMap['link'] ?? null;
+    $isVirtual = array_key_exists('virtual', $tagMap);
+
+    foreach ($tags as $tag) {
+        if ($tag->name === 'var') {
+            $phpDocType = $tag->getType();
+        }
+    }
+
+    $propertyType = $type ? Type::fromNode($type) : null;
+    if ($propertyType === null && !$phpDocType) {
+        throw new Exception("Missing type for property $class::\$$property->name");
+    }
+
+    if (
+        $property->default instanceof Expr\ConstFetch &&
+        $property->default->name->toLowerString() === "null" &&
+        $propertyType && !$propertyType->isNullable()
+    ) {
+        $simpleType = $propertyType->tryToSimpleType();
+        if ($simpleType === null || !$simpleType->isMixed()) {
+            throw new Exception("Property $class::\$$property->name has null default, but is not nullable");
+        }
+    }
+
+    return new PropertyInfo(
+        new PropertyName($class, $property->name->__toString()),
+        $classFlags,
+        $flags,
+        $propertyType,
+        $phpDocType ? Type::fromString($phpDocType) : null,
+        $property->default,
+        $property->default ? $prettyPrinter->prettyPrintExpr($property->default) : null,
+        $isDocReadonly,
+        $isVirtual,
+        $link,
+        $phpVersionIdMinimumCompatibility,
+        $attributes,
+        ExposedDocComment::extractExposedComment($comments)
+    );
+}
+
+/**
+ * @param ConstInfo[] $consts
+ * @param PropertyInfo[] $properties
+ * @param FuncInfo[] $methods
+ * @param EnumCaseInfo[] $enumCases
+ */
+function parseClass(
+    Name $name,
+    Stmt\ClassLike $class,
+    array $consts,
+    array $properties,
+    array $methods,
+    array $enumCases,
+    ?string $cond,
+    ?int $minimumPhpVersionIdCompatibility,
+    bool $isUndocumentable
+): ClassInfo {
+    $comments = $class->getComments();
+    $alias = null;
+    $allowsDynamicProperties = false;
+
+    $tags = DocCommentTag::parseDocComments($comments);
+    $tagMap = DocCommentTag::makeTagMap($tags);
+
+    $isDeprecated = array_key_exists('deprecated', $tagMap);
+    $isStrictProperties = array_key_exists('strict-properties', $tagMap);
+    $isNotSerializable = array_key_exists('not-serializable', $tagMap);
+    $isUndocumentable = $isUndocumentable || array_key_exists('undocumentable', $tagMap);
+    foreach ($tags as $tag) {
+        if ($tag->name === 'alias') {
+            $alias = $tag->getValue();
+        }
+    }
+
+    $attributes = AttributeInfo::createFromGroups($class->attrGroups);
+    foreach ($attributes as $attribute) {
+        switch ($attribute->class) {
+            case 'AllowDynamicProperties':
+                $allowsDynamicProperties = true;
+                break 2;
+        }
+    }
+
+    if ($isStrictProperties && $allowsDynamicProperties) {
+        throw new Exception("A class may not have '@strict-properties' and '#[\\AllowDynamicProperties]' at the same time.");
+    }
+
+    $extends = [];
+    $implements = [];
+
+    if ($class instanceof Class_) {
+        $classKind = "class";
+        if ($class->extends) {
+            $extends[] = $class->extends;
+        }
+        $implements = $class->implements;
+    } elseif ($class instanceof Interface_) {
+        $classKind = "interface";
+        $extends = $class->extends;
+    } else if ($class instanceof Trait_) {
+        $classKind = "trait";
+    } else if ($class instanceof Enum_) {
+        $classKind = "enum";
+        $implements = $class->implements;
+    } else {
+        throw new Exception("Unknown class kind " . get_class($class));
+    }
+
+    if ($isUndocumentable) {
+        foreach ($methods as $method) {
+            $method->isUndocumentable = true;
+        }
+    }
+
+    return new ClassInfo(
+        $name,
+        $class instanceof Class_ ? $class->flags : 0,
+        $classKind,
+        $alias,
+        $class instanceof Enum_ && $class->scalarType !== null
+            ? SimpleType::fromNode($class->scalarType) : null,
+        $isDeprecated,
+        $isStrictProperties,
+        $attributes,
+        ExposedDocComment::extractExposedComment($comments),
+        $isNotSerializable,
+        $extends,
+        $implements,
+        $consts,
+        $properties,
+        $methods,
+        $enumCases,
+        $cond,
+        $minimumPhpVersionIdCompatibility,
+        $isUndocumentable
+    );
+}
+
+/**
+ * @template T
+ * @param iterable<T> $infos
+ * @param Closure(T): string|null $codeGenerator
+ * @param ?string $parentCond
+ */
+function generateCodeWithConditions(
+    iterable $infos,
+    string $separator,
+    Closure $codeGenerator,
+    ?string $parentCond = null
+): string {
+    $code = "";
+
+    // For combining the conditional blocks of the infos with the same condition
+    $openCondition = null;
+    foreach ($infos as $info) {
+        $infoCode = $codeGenerator($info);
+        if ($infoCode === null) {
+            continue;
+        }
+
+        if ($info->cond && $info->cond !== $parentCond) {
+            if (
+                $openCondition !== null
+                && $info->cond !== $openCondition
+            ) {
+                // Changing condition, end old
+                $code .= "#endif\n";
+                $code .= $separator;
+                $code .= "#if {$info->cond}\n";
+                $openCondition = $info->cond;
+            } elseif ($openCondition === null) {
+                // New condition with no existing one
+                $code .= $separator;
+                $code .= "#if {$info->cond}\n";
+                $openCondition = $info->cond;
+            } else {
+                // Staying in the same condition
+                $code .= $separator;
+            }
+            $code .= $infoCode;
+        } else {
+            if ($openCondition !== null) {
+                // Ending the condition
+                $code .= "#endif\n";
+                $openCondition = null;
+            }
+            $code .= $separator;
+            $code .= $infoCode;
+        }
+    }
+    // The last info might have been in a conditional block
+    if ($openCondition !== null) {
+        $code .= "#endif\n";
+    }
+
+    return $code;
+}
+
+/**
+ * @param array<string, ConstInfo> $allConstInfos
+ */
+function generateArgInfoCode(
+    string $stubFilenameWithoutExtension,
+    FileInfo $fileInfo,
+    array $allConstInfos,
+    string $stubHash
+): string {
+    $code = "/* This is a generated file, edit the .stub.php file instead.\n"
+        . " * Stub hash: $stubHash */\n";
+
+    $generatedFuncInfos = [];
+
+    $argInfoCode = generateCodeWithConditions(
+        $fileInfo->getAllFuncInfos(),
+        "\n",
+        static function (FuncInfo $funcInfo) use (&$generatedFuncInfos, $fileInfo) {
+            /* If there already is an equivalent arginfo structure, only emit a #define */
+            if ($generatedFuncInfo = $funcInfo->findEquivalent($generatedFuncInfos)) {
+                $code = sprintf(
+                    "#define %s %s\n",
+                    $funcInfo->getArgInfoName(),
+                    $generatedFuncInfo->getArgInfoName()
+                );
+            } else {
+                $code = $funcInfo->toArgInfoCode($fileInfo->getMinimumPhpVersionIdCompatibility());
+            }
+
+            $generatedFuncInfos[] = $funcInfo;
+            return $code;
+        }
+    );
+
+    if ($argInfoCode !== "") {
+        $code .= "$argInfoCode\n";
+    }
+
+    if ($fileInfo->generateFunctionEntries) {
+        $framelessFunctionCode = generateCodeWithConditions(
+            $fileInfo->getAllFuncInfos(),
+            "\n",
+            static function (FuncInfo $funcInfo) {
+                return $funcInfo->getFramelessDeclaration();
+            }
+        );
+
+        if ($framelessFunctionCode !== "") {
+            $code .= "$framelessFunctionCode\n";
+        }
+
+        $generatedFunctionDeclarations = [];
+        $code .= generateCodeWithConditions(
+            $fileInfo->getAllFuncInfos(),
+            "",
+            static function (FuncInfo $funcInfo) use ($fileInfo, &$generatedFunctionDeclarations) {
+                $key = $funcInfo->getDeclarationKey();
+                if (isset($generatedFunctionDeclarations[$key])) {
+                    return null;
+                }
+
+                $generatedFunctionDeclarations[$key] = true;
+                return $fileInfo->declarationPrefix . $funcInfo->getDeclaration();
+            }
+        );
+
+        $code .= generateFunctionEntries(null, $fileInfo->funcInfos);
+
+        foreach ($fileInfo->classInfos as $classInfo) {
+            $code .= generateFunctionEntries($classInfo->name, $classInfo->funcInfos, $classInfo->cond);
+        }
+    }
+
+    $php80MinimumCompatibility = $fileInfo->getMinimumPhpVersionIdCompatibility() === null || $fileInfo->getMinimumPhpVersionIdCompatibility() >= PHP_80_VERSION_ID;
+
+    if ($fileInfo->generateClassEntries) {
+        $declaredStrings = [];
+        $attributeInitializationCode = generateFunctionAttributeInitialization($fileInfo->funcInfos, $allConstInfos, $fileInfo->getMinimumPhpVersionIdCompatibility(), null, $declaredStrings);
+        $attributeInitializationCode .= generateGlobalConstantAttributeInitialization($fileInfo->constInfos, $allConstInfos, $fileInfo->getMinimumPhpVersionIdCompatibility(), null, $declaredStrings);
+        if ($attributeInitializationCode) {
+            if (!$php80MinimumCompatibility) {
+                $attributeInitializationCode = "\n#if (PHP_VERSION_ID >= " . PHP_80_VERSION_ID . ")" . $attributeInitializationCode . "#endif\n";
+            }
+        }
+
+        if ($attributeInitializationCode !== "" || !empty($fileInfo->constInfos)) {
+            $code .= "\nstatic void register_{$stubFilenameWithoutExtension}_symbols(int module_number)\n";
+            $code .= "{\n";
+
+            $code .= generateCodeWithConditions(
+                $fileInfo->constInfos,
+                '',
+                static fn(ConstInfo $constInfo): string => $constInfo->getDeclaration($allConstInfos)
+            );
+
+            if ($attributeInitializationCode !== "" && $fileInfo->constInfos) {
+                $code .= "\n";
+            }
+
+            $code .= $attributeInitializationCode;
+            $code .= "}\n";
+        }
+
+        $code .= $fileInfo->generateClassEntryCode($allConstInfos);
+    }
+
+    return $code;
+}
+
+/** @param FuncInfo[] $funcInfos */
+function generateFunctionEntries(?Name $className, array $funcInfos, ?string $cond = null): string
+{
+    // No need to add anything if there are no function entries
+    if ($funcInfos === []) {
+        return '';
+    }
+
+    $functionEntryName = "ext_functions";
+    if ($className) {
+        $underscoreName = implode("_", $className->getParts());
+        $functionEntryName = "class_{$underscoreName}_methods";
+    }
+
+    $code = "\nstatic const zend_function_entry {$functionEntryName}[] = {\n";
+    $code .= generateCodeWithConditions($funcInfos, "", static function (FuncInfo $funcInfo) {
+        return $funcInfo->getFunctionEntry();
+    }, $cond);
+    $code .= "\tZEND_FE_END\n";
+    $code .= "};\n";
+
+    if ($cond) {
+        $code = "\n#if {$cond}{$code}#endif\n";
+    }
+
+    return $code;
+}
+
+/**
+ * @param iterable<FuncInfo> $funcInfos
+ * @param array<string, string> &$declaredStrings Map of string content to
+ *   the name of a zend_string already created with that content
+ */
+function generateFunctionAttributeInitialization(iterable $funcInfos, array $allConstInfos, ?int $phpVersionIdMinimumCompatibility, ?string $parentCond = null, array &$declaredStrings = []): string
+{
+    return generateCodeWithConditions(
+        $funcInfos,
+        "",
+        static function (FuncInfo $funcInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, &$declaredStrings) {
+            $code = null;
+
+            if ($funcInfo->name instanceof MethodName) {
+                $functionTable = "&class_entry->function_table";
+            } else {
+                $functionTable = "CG(function_table)";
+            }
+
+            // Make sure we don't try and use strings that might only be
+            // conditionally available; string reuse is only among declarations
+            // that are always there
+            if ($funcInfo->cond) {
+                $useDeclared = [];
+            } else {
+                $useDeclared = &$declaredStrings;
+            }
+
+            foreach ($funcInfo->attributes as $key => $attribute) {
+                $code .= $attribute->generateCode(
+                    "zend_add_function_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", sizeof(\"" . $funcInfo->name->getNameForAttributes() . "\") - 1)",
+                    "func_" . $funcInfo->name->getNameForAttributes() . "_$key",
+                    $allConstInfos,
+                    $phpVersionIdMinimumCompatibility,
+                    $useDeclared
+                );
+            }
+
+            foreach ($funcInfo->args as $index => $arg) {
+                foreach ($arg->attributes as $key => $attribute) {
+                    $code .= $attribute->generateCode(
+                        "zend_add_parameter_attribute(zend_hash_str_find_ptr($functionTable, \"" . $funcInfo->name->getNameForAttributes() . "\", sizeof(\"" . $funcInfo->name->getNameForAttributes() . "\") - 1), $index",
+                        "func_{$funcInfo->name->getNameForAttributes()}_arg{$index}_$key",
+                        $allConstInfos,
+                        $phpVersionIdMinimumCompatibility,
+                        $useDeclared
+                    );
+                }
+            }
+
+            return $code;
+        },
+        $parentCond
+    );
+}
+
+/**
+ * @param iterable<ConstInfo> $constInfos
+ * @param array<string, ConstInfo> $allConstInfos
+ * @param array<string, string> &$declaredStrings Map of string content to
+ *   the name of a zend_string already created with that content
+ */
+function generateGlobalConstantAttributeInitialization(
+    iterable $constInfos,
+    array $allConstInfos,
+    ?int $phpVersionIdMinimumCompatibility,
+    ?string $parentCond = null,
+    array &$declaredStrings = []
+): string {
+    $isConditional = false;
+    if ($phpVersionIdMinimumCompatibility !== null && $phpVersionIdMinimumCompatibility < PHP_85_VERSION_ID) {
+        $isConditional = true;
+    }
+    $code = generateCodeWithConditions(
+        $constInfos,
+        "",
+        static function (ConstInfo $constInfo) use ($allConstInfos, $isConditional, &$declaredStrings) {
+            $code = "";
+
+            if ($constInfo->attributes === []) {
+                return null;
+            }
+            // Make sure we don't try and use strings that might only be
+            // conditionally available; string reuse is only among declarations
+            // that are always there
+            if ($constInfo->cond) {
+                $useDeclared = [];
+            } else {
+                $useDeclared = &$declaredStrings;
+            }
+            $constName = str_replace('\\', '\\\\', $constInfo->name->__toString());
+            $constVarName = 'const_' . $constName;
+
+            // The entire attribute block will be conditional if PHP < 8.5 is
+            // supported, but also if PHP < 8.5 is supported we need to search
+            // for the constant; see GH-19029
+            if ($isConditional) {
+                $code .= "\tzend_constant *$constVarName = zend_hash_str_find_ptr(EG(zend_constants), \"" . $constName . "\", sizeof(\"" . $constName . "\") - 1);\n";
+            }
+            foreach ($constInfo->attributes as $key => $attribute) {
+                $code .= $attribute->generateCode(
+                    "zend_add_global_constant_attribute($constVarName",
+                    $constVarName . "_$key",
+                    $allConstInfos,
+                    PHP_85_VERSION_ID,
+                    $useDeclared
+                );
+            }
+
+            return $code;
+        },
+        $parentCond
+    );
+    if ($code && $isConditional) {
+        return "\n#if (PHP_VERSION_ID >= " . PHP_85_VERSION_ID . ")\n" . $code . "#endif\n";
+    }
+    return $code;
+}
+
+/**
+ * @param iterable<ConstInfo> $constInfos
+ * @param array<string, ConstInfo> $allConstInfos
+ * @param array<string, string> &$declaredStrings Map of string content to
+ *    the name of a zend_string already created with that content
+ */
+function generateConstantAttributeInitialization(
+    iterable $constInfos,
+    array $allConstInfos,
+    ?int $phpVersionIdMinimumCompatibility,
+    ?string $parentCond = null,
+    array &$declaredStrings = []
+): string {
+    return generateCodeWithConditions(
+        $constInfos,
+        "",
+        static function (ConstInfo $constInfo) use ($allConstInfos, $phpVersionIdMinimumCompatibility, &$declaredStrings) {
+            $code = null;
+
+            // Make sure we don't try and use strings that might only be
+            // conditionally available; string reuse is only among declarations
+            // that are always there
+            if ($constInfo->cond) {
+                $useDeclared = [];
+            } else {
+                $useDeclared = &$declaredStrings;
+            }
+            foreach ($constInfo->attributes as $key => $attribute) {
+                $code .= $attribute->generateCode(
+                    "zend_add_class_constant_attribute(class_entry, const_" . $constInfo->name->getDeclarationName(),
+                    "const_" . $constInfo->name->getDeclarationName() . "_$key",
+                    $allConstInfos,
+                    $phpVersionIdMinimumCompatibility,
+                    $useDeclared
+                );
+            }
+
+            return $code;
+        },
+        $parentCond
+    );
+}
+
+/**
+ * @param iterable<PropertyInfo> $propertyInfos
+ * @param array<string, ConstInfo> $allConstInfos
+ * @param array<string, string> &$declaredStrings Map of string content to
+ *    the name of a zend_string already created with that content
+ */
+function generatePropertyAttributeInitialization(
+    iterable $propertyInfos,
+    array $allConstInfos,
+    ?int $phpVersionIdMinimumCompatibility,
+    array &$declaredStrings
+): string {
+    $code = "";
+    foreach ($propertyInfos as $propertyInfo) {
+        foreach ($propertyInfo->attributes as $key => $attribute) {
+            $code .= $attribute->generateCode(
+                "zend_add_property_attribute(class_entry, property_" . $propertyInfo->name->getDeclarationName(),
+                "property_" . $propertyInfo->name->getDeclarationName() . "_" . $key,
+                $allConstInfos,
+                $phpVersionIdMinimumCompatibility,
+                $declaredStrings
+            );
+        }
+    }
+
+    return $code;
+}
+
+/** @param array<string, FuncInfo> $funcMap */
+function generateOptimizerInfo(array $funcMap): string
+{
+    $code = "/* This is a generated file, edit the .stub.php files instead. */\n\n";
+
+    $code .= "static const func_info_t func_infos[] = {\n";
+
+    $code .= generateCodeWithConditions($funcMap, "", static function (FuncInfo $funcInfo) {
+        return $funcInfo->getOptimizerInfo();
+    });
+
+    $code .= "};\n";
+
+    return $code;
+}
+
+/**
+ * @param array<string, ConstInfo> $constMap
+ * @param array<string, ConstInfo> $undocumentedConstMap
+ * @return array<string, string|null>
+ */
+function replacePredefinedConstants(string $targetDirectory, array $constMap, array &$undocumentedConstMap): array
+{
+    /** @var array<string, string> $documentedConstMap */
+    $documentedConstMap = [];
+    /** @var array<string, string> $predefinedConstants */
+    $predefinedConstants = [];
+
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($targetDirectory),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    foreach ($it as $file) {
+        $pathName = $file->getPathName();
+        if (!preg_match('/(?:[\w\.]*constants[\w\._]*|tokens).xml$/i', basename($pathName))) {
+            continue;
+        }
+
+        $xml = file_get_contents($pathName);
+        if ($xml === false) {
+            continue;
+        }
+
+        if (
+            stripos($xml, "<appendix") === false && stripos($xml, "<sect2") === false &&
+            stripos($xml, "<chapter") === false && stripos($xml, 'role="constant_list"') === false
+        ) {
+            continue;
+        }
+
+        $replacedXml = getReplacedSynopsisXml($xml);
+
+        $doc = new DOMDocument();
+        $doc->formatOutput = false;
+        $doc->preserveWhiteSpace = true;
+        $doc->validateOnParse = true;
+        $success = $doc->loadXML($replacedXml);
+        if (!$success) {
+            echo "Failed opening $pathName\n";
+            continue;
+        }
+
+        $updated = false;
+
+        foreach ($doc->getElementsByTagName("varlistentry") as $entry) {
+            if (!$entry instanceof DOMElement) {
+                continue;
+            }
+
+            foreach ($entry->getElementsByTagName("term") as $manualTermElement) {
+                $manualConstantElement = $manualTermElement->getElementsByTagName("constant")->item(0);
+                if (!$manualConstantElement instanceof DOMElement) {
+                    continue;
+                }
+
+                $manualConstantName = $manualConstantElement->textContent;
+
+                $stubConstant = $constMap[$manualConstantName] ?? null;
+                if ($stubConstant === null) {
+                    continue;
+                }
+
+                $documentedConstMap[$manualConstantName] = $manualConstantName;
+
+                if ($entry->firstChild instanceof DOMText) {
+                    $indentationLevel = strlen(str_replace("\n", "", $entry->firstChild->textContent));
+                } else {
+                    $indentationLevel = 3;
+                }
+                $newTermElement = $stubConstant->getPredefinedConstantTerm($doc, $indentationLevel);
+
+                if ($manualTermElement->textContent === $newTermElement->textContent) {
+                    continue;
+                }
+
+                $manualTermElement->parentNode->replaceChild($newTermElement, $manualTermElement);
+                $updated = true;
+            }
+        }
+
+        foreach ($doc->getElementsByTagName("row") as $row) {
+            if (!$row instanceof DOMElement) {
+                continue;
+            }
+
+            $entry = $row->getElementsByTagName("entry")->item(0);
+            if (!$entry instanceof DOMElement) {
+                continue;
+            }
+
+            foreach ($entry->getElementsByTagName("constant") as $manualConstantElement) {
+                if (!$manualConstantElement instanceof DOMElement) {
+                    continue;
+                }
+
+                $manualConstantName = $manualConstantElement->textContent;
+
+                $stubConstant = $constMap[$manualConstantName] ?? null;
+                if ($stubConstant === null) {
+                    continue;
+                }
+
+                $documentedConstMap[$manualConstantName] = $manualConstantName;
+
+                if ($row->firstChild instanceof DOMText) {
+                    $indentationLevel = strlen(str_replace("\n", "", $row->firstChild->textContent));
+                } else {
+                    $indentationLevel = 3;
+                }
+                $newEntryElement = $stubConstant->getPredefinedConstantEntry($doc, $indentationLevel);
+
+                if ($entry->textContent === $newEntryElement->textContent) {
+                    continue;
+                }
+
+                $entry->parentNode->replaceChild($newEntryElement, $entry);
+                $updated = true;
+            }
+        }
+
+        if ($updated) {
+            $replacedXml = $doc->saveXML();
+
+            $replacedXml = preg_replace(
+                [
+                    "/REPLACED-ENTITY-([A-Za-z0-9._{}%-]+?;)/",
+                    '/<appendix\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<appendix\s+xmlns="([^"]+)"\s+xmlns:xlink="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<sect2\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<sect2\s+xmlns="([^"]+)"\s+xmlns:xlink="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<chapter\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<chapter\s+xmlns="([^"]+)"\s+xmlns:xlink="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                ],
+                [
+                    "&$1",
+                    "<appendix xml:id=\"$2\" xmlns=\"$1\">",
+                    "<appendix xml:id=\"$3\" xmlns=\"$1\" xmlns:xlink=\"$2\">",
+                    "<sect2 xml:id=\"$2\" xmlns=\"$1\">",
+                    "<sect2 xml:id=\"$3\" xmlns=\"$1\" xmlns:xlink=\"$2\">",
+                    "<chapter xml:id=\"$2\" xmlns=\"$1\">",
+                    "<chapter xml:id=\"$3\" xmlns=\"$1\" xmlns:xlink=\"$2\">",
+                ],
+                $replacedXml
+            );
+
+            $predefinedConstants[$pathName] = $replacedXml;
+        }
+    }
+
+    $undocumentedConstMap = array_diff_key($constMap, $documentedConstMap);
+
+    return $predefinedConstants;
+}
+
+/**
+ * @param array<string, ClassInfo> $classMap
+ * @param array<string, ConstInfo> $allConstInfos
+ * @return array<string, string>
+ */
+function generateClassSynopses(array $classMap, array $allConstInfos): array
+{
+    $result = [];
+
+    foreach ($classMap as $classInfo) {
+        $classSynopsis = $classInfo->getClassSynopsisDocument($classMap, $allConstInfos);
+        if ($classSynopsis !== null) {
+            $result[ClassInfo::getClassSynopsisFilename($classInfo->name) . ".xml"] = $classSynopsis;
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * @param array<string, ClassInfo> $classMap
+ * @param array<string, ConstInfo> $allConstInfos
+ * @param array<string, ClassInfo> $undocumentedClassMap
+ * @return array<string, string>
+ */
+function replaceClassSynopses(
+    string $targetDirectory,
+    array $classMap,
+    array $allConstInfos,
+    array &$undocumentedClassMap
+): array {
+    /** @var array<string, string> $documentedClassMap */
+    $documentedClassMap = [];
+    /** @var array<string, string> $classSynopses */
+    $classSynopses = [];
+
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($targetDirectory),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    foreach ($it as $file) {
+        $pathName = $file->getPathName();
+        if (!preg_match('/\.xml$/i', $pathName)) {
+            continue;
+        }
+
+        $xml = file_get_contents($pathName);
+        if ($xml === false) {
+            continue;
+        }
+
+        if (stripos($xml, "<classsynopsis") === false) {
+            continue;
+        }
+
+        $replacedXml = getReplacedSynopsisXml($xml);
+
+        $doc = new DOMDocument();
+        $doc->formatOutput = false;
+        $doc->preserveWhiteSpace = true;
+        $doc->validateOnParse = true;
+        $success = $doc->loadXML($replacedXml);
+        if (!$success) {
+            echo "Failed opening $pathName\n";
+            continue;
+        }
+
+        $classSynopsisElements = [];
+        foreach ($doc->getElementsByTagName("classsynopsis") as $element) {
+            $classSynopsisElements[] = $element;
+        }
+
+        foreach ($classSynopsisElements as $classSynopsis) {
+            if (!$classSynopsis instanceof DOMElement) {
+                continue;
+            }
+
+            $child = $classSynopsis->firstElementChild;
+            if ($child === null) {
+                continue;
+            }
+            $child = $child->lastElementChild;
+            if ($child === null) {
+                continue;
+            }
+            $className = $child->textContent;
+            if (!isset($classMap[$className])) {
+                continue;
+            }
+
+            $documentedClassMap[$className] = $className;
+
+            $classInfo = $classMap[$className];
+
+            $newClassSynopsis = $classInfo->getClassSynopsisElement($doc, $classMap, $allConstInfos);
+            if ($newClassSynopsis === null) {
+                continue;
+            }
+
+            // Check if there is any change - short circuit if there is not any.
+
+            if (replaceAndCompareXmls($doc, $classSynopsis, $newClassSynopsis)) {
+                continue;
+            }
+
+            // Return the updated XML
+
+            $replacedXml = $doc->saveXML();
+
+            $replacedXml = preg_replace(
+                [
+                    "/REPLACED-ENTITY-([A-Za-z0-9._{}%-]+?;)/",
+                    '/<reference\s+role="(\w+)"\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<reference\s+role="(\w+)"\s+xmlns="([^"]+)"\s+xmlns:xi="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<reference\s+role="(\w+)"\s+xmlns="([^"]+)"\s+xmlns:xlink="([^"]+)"\s+xmlns:xi="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<reference\s+role="(\w+)"\s+xmlns:xlink="([^"]+)"\s+xmlns:xi="([^"]+)"\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<reference\s+xmlns=\"([^"]+)\"\s+xmlns:xlink="([^"]+)"\s+xmlns:xi="([^"]+)"\s+role="(\w+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<reference\s+xmlns=\"([^"]+)\"\s+xmlns:xlink="([^"]+)"\s+xmlns:xi="([^"]+)"\s+xml:id="([^"]+)"\s+role="(\w+)"\s*>/i',
+                ],
+                [
+                    "&$1",
+                    "<reference xml:id=\"$3\" role=\"$1\" xmlns=\"$2\">",
+                    "<reference xml:id=\"$4\" role=\"$1\" xmlns=\"$2\" xmlns:xi=\"$3\">",
+                    "<reference xml:id=\"$5\" role=\"$1\" xmlns=\"$2\" xmlns:xlink=\"$3\" xmlns:xi=\"$4\">",
+                    "<reference xml:id=\"$5\" role=\"$1\" xmlns=\"$4\" xmlns:xlink=\"$2\" xmlns:xi=\"$2\">",
+                    "<reference xml:id=\"$5\" role=\"$4\" xmlns=\"$1\" xmlns:xlink=\"$2\" xmlns:xi=\"$3\">",
+                    "<reference xml:id=\"$4\" role=\"$5\" xmlns=\"$1\" xmlns:xlink=\"$2\" xmlns:xi=\"$3\">",
+                ],
+                $replacedXml
+            );
+
+            $classSynopses[$pathName] = $replacedXml;
+        }
+    }
+
+    $undocumentedClassMap = array_diff_key($classMap, $documentedClassMap);
+
+    return $classSynopses;
+}
+
+function getReplacedSynopsisXml(string $xml): string
+{
+    return preg_replace(
+        [
+            "/&([A-Za-z0-9._{}%-]+?;)/",
+            "/<(\/)*xi:([A-Za-z]+?)/"
+        ],
+        [
+            "REPLACED-ENTITY-$1",
+            "<$1XI$2",
+        ],
+        $xml
+    );
+}
+
+/**
+ * @param array<string, FuncInfo> $funcMap
+ * @return array<string, string>
+ */
+function generateMethodSynopses(array $funcMap): array
+{
+    $result = [];
+
+    foreach ($funcMap as $funcInfo) {
+        $methodSynopsis = $funcInfo->getMethodSynopsisDocument();
+        if ($methodSynopsis !== null) {
+            $result[$funcInfo->name->getMethodSynopsisFilename() . ".xml"] = $methodSynopsis;
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * @param array<string, FuncInfo> $funcMap
+ * @param array<int, string> $methodSynopsisWarnings
+ * @param array<string, FuncInfo> $undocumentedFuncMap
+ * @return array<string, string>
+ */
+function replaceMethodSynopses(
+    string $targetDirectory,
+    array $funcMap,
+    bool $isVerifyManual,
+    array &$methodSynopsisWarnings,
+    array &$undocumentedFuncMap
+): array {
+    /** @var array<string, string> $documentedFuncMap */
+    $documentedFuncMap = [];
+    /** @var array<string, string> $methodSynopses */
+    $methodSynopses = [];
+
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($targetDirectory),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    foreach ($it as $file) {
+        $pathName = $file->getPathName();
+        if (!preg_match('/\.xml$/i', $pathName)) {
+            continue;
+        }
+
+        $xml = file_get_contents($pathName);
+        if ($xml === false) {
+            continue;
+        }
+
+        if ($isVerifyManual) {
+            $matches = [];
+            preg_match("/<refname>\s*([\w:]+)\s*<\/refname>\s*<refpurpose>\s*&Alias;\s*<(?:function|methodname)>\s*([\w:]+)\s*<\/(?:function|methodname)>\s*<\/refpurpose>/i", $xml, $matches);
+            $aliasName = $matches[1] ?? null;
+            $alias = $funcMap[$aliasName] ?? null;
+            $funcName = $matches[2] ?? null;
+            $func = $funcMap[$funcName] ?? null;
+
+            if (
+                $alias &&
+                !$alias->isUndocumentable &&
+                ($func === null || $func->alias === null || $func->alias->__toString() !== $aliasName) &&
+                ($alias->alias === null || $alias->alias->__toString() !== $funcName)
+            ) {
+                $methodSynopsisWarnings[] = "$aliasName()" . ($alias->alias ? " is an alias of " . $alias->alias->__toString() . "(), but it" : "") . " is incorrectly documented as an alias for $funcName()";
+            }
+
+            $matches = [];
+            preg_match("/<(?:para|simpara)>\s*(?:&info.function.alias;|&info.method.alias;|&Alias;)\s+<(?:function|methodname)>\s*([\w:]+)\s*<\/(?:function|methodname)>/i", $xml, $matches);
+            $descriptionFuncName = $matches[1] ?? null;
+            $descriptionFunc = $funcMap[$descriptionFuncName] ?? null;
+            if ($descriptionFunc && $funcName !== $descriptionFuncName) {
+                $methodSynopsisWarnings[] = "Alias in the method synopsis description of $pathName doesn't match the alias in the <refpurpose>";
+            }
+
+            if ($aliasName) {
+                $documentedFuncMap[$aliasName] = $aliasName;
+            }
+        }
+
+        if (stripos($xml, "<methodsynopsis") === false && stripos($xml, "<constructorsynopsis") === false && stripos($xml, "<destructorsynopsis") === false) {
+            continue;
+        }
+
+        $replacedXml = getReplacedSynopsisXml($xml);
+
+        $doc = new DOMDocument();
+        $doc->formatOutput = false;
+        $doc->preserveWhiteSpace = true;
+        $doc->validateOnParse = true;
+        $success = $doc->loadXML($replacedXml);
+        if (!$success) {
+            echo "Failed opening $pathName\n";
+            continue;
+        }
+
+        $methodSynopsisElements = [];
+        foreach ($doc->getElementsByTagName("constructorsynopsis") as $element) {
+            $methodSynopsisElements[] = $element;
+        }
+        foreach ($doc->getElementsByTagName("destructorsynopsis") as $element) {
+            $methodSynopsisElements[] = $element;
+        }
+        foreach ($doc->getElementsByTagName("methodsynopsis") as $element) {
+            $methodSynopsisElements[] = $element;
+        }
+
+        foreach ($methodSynopsisElements as $methodSynopsis) {
+            if (!$methodSynopsis instanceof DOMElement) {
+                continue;
+            }
+
+            $item = $methodSynopsis->getElementsByTagName("methodname")->item(0);
+            if (!$item instanceof DOMElement) {
+                continue;
+            }
+            $funcName = $item->textContent;
+            if (!isset($funcMap[$funcName])) {
+                continue;
+            }
+
+            $funcInfo = $funcMap[$funcName];
+            $documentedFuncMap[$funcInfo->name->__toString()] = $funcInfo->name->__toString();
+
+            $newMethodSynopsis = $funcInfo->getMethodSynopsisElement($doc);
+            if ($newMethodSynopsis === null) {
+                continue;
+            }
+
+            // Retrieve current signature
+
+            $params = [];
+            $list = $methodSynopsis->getElementsByTagName("methodparam");
+            foreach ($list as $i => $item) {
+                if (!$item instanceof DOMElement) {
+                    continue;
+                }
+
+                $paramList = $item->getElementsByTagName("parameter");
+                if ($paramList->count() !== 1) {
+                    continue;
+                }
+
+                $paramName = $paramList->item(0)->textContent;
+                $paramTypes = [];
+
+                $paramList = $item->getElementsByTagName("type");
+                foreach ($paramList as $type) {
+                    if (!$type instanceof DOMElement) {
+                        continue;
+                    }
+
+                    $paramTypes[] = $type->textContent;
+                }
+
+                $params[$paramName] = ["index" => $i, "type" => $paramTypes];
+            }
+
+            // Check if there is any change - short circuit if there is not any.
+
+            if (replaceAndCompareXmls($doc, $methodSynopsis, $newMethodSynopsis)) {
+                continue;
+            }
+
+            // Update parameter references
+
+            $paramList = $doc->getElementsByTagName("parameter");
+            /** @var DOMElement $paramElement */
+            foreach ($paramList as $paramElement) {
+                if ($paramElement->parentNode && $paramElement->parentNode->nodeName === "methodparam") {
+                    continue;
+                }
+
+                $name = $paramElement->textContent;
+                if (!isset($params[$name])) {
+                    continue;
+                }
+
+                $index = $params[$name]["index"];
+                if (!isset($funcInfo->args[$index])) {
+                    continue;
+                }
+
+                $paramElement->textContent = $funcInfo->args[$index]->name;
+            }
+
+            // Return the updated XML
+
+            $replacedXml = $doc->saveXML();
+
+            $replacedXml = preg_replace(
+                [
+                    "/REPLACED-ENTITY-([A-Za-z0-9._{}%-]+?;)/",
+                    '/<refentry\s+xmlns="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                    '/<refentry\s+xmlns="([^"]+)"\s+xmlns:xlink="([^"]+)"\s+xml:id="([^"]+)"\s*>/i',
+                ],
+                [
+                    "&$1",
+                    "<refentry xml:id=\"$2\" xmlns=\"$1\">",
+                    "<refentry xml:id=\"$3\" xmlns=\"$1\" xmlns:xlink=\"$2\">",
+                ],
+                $replacedXml
+            );
+
+            $methodSynopses[$pathName] = $replacedXml;
+        }
+    }
+
+    $undocumentedFuncMap = array_diff_key($funcMap, $documentedFuncMap);
+
+    return $methodSynopses;
+}
+
+function replaceAndCompareXmls(DOMDocument $doc, DOMElement $originalSynopsis, DOMElement $newSynopsis): bool
+{
+    $docComparator = new DOMDocument();
+    $docComparator->preserveWhiteSpace = false;
+    $docComparator->formatOutput = true;
+
+    $xml1 = $doc->saveXML($originalSynopsis);
+    $xml1 = getReplacedSynopsisXml($xml1);
+    $docComparator->loadXML($xml1);
+    $xml1 = $docComparator->saveXML();
+
+    $originalSynopsis->parentNode->replaceChild($newSynopsis, $originalSynopsis);
+
+    $xml2 = $doc->saveXML($newSynopsis);
+    $xml2 = getReplacedSynopsisXml($xml2);
+
+    $docComparator->loadXML($xml2);
+    $xml2 = $docComparator->saveXML();
+
+    return $xml1 === $xml2;
+}
+
+function installPhpParser(string $version, string $phpParserDir)
+{
+    $lockFile = __DIR__ . "/PHP-Parser-install-lock";
+    $lockFd = fopen($lockFile, 'w+');
+    if (!flock($lockFd, LOCK_EX)) {
+        throw new Exception("Failed to acquire installation lock");
+    }
+
+    try {
+        // Check whether a parallel process has already installed PHP-Parser.
+        if (is_dir($phpParserDir)) {
+            return;
+        }
+
+        $cwd = getcwd();
+        chdir(__DIR__);
+
+        $tarName = "v$version.tar.gz";
+        passthru("wget https://github.com/nikic/PHP-Parser/archive/$tarName", $exit);
+        if ($exit !== 0) {
+            passthru("curl -LO https://github.com/nikic/PHP-Parser/archive/$tarName", $exit);
+        }
+        if ($exit !== 0) {
+            throw new Exception("Failed to download PHP-Parser tarball");
+        }
+        if (!mkdir($phpParserDir)) {
+            throw new Exception("Failed to create directory $phpParserDir");
+        }
+        passthru("tar xvzf $tarName -C PHP-Parser-$version --strip-components 1", $exit);
+        if ($exit !== 0) {
+            throw new Exception("Failed to extract PHP-Parser tarball");
+        }
+        unlink(__DIR__ . "/$tarName");
+        chdir($cwd);
+    } finally {
+        flock($lockFd, LOCK_UN);
+        @unlink($lockFile);
+    }
+}
+
+function initPhpParser()
+{
+    static $isInitialized = false;
+    if ($isInitialized) {
+        return;
+    }
+
+    if (!extension_loaded("tokenizer")) {
+        throw new Exception("The \"tokenizer\" extension is not available");
+    }
+
+    $isInitialized = true;
+
+    // Try composer autoloader first
+    foreach ([__DIR__ . "/vendor/autoload.php", dirname(__DIR__) . "/vendor/autoload.php"] as $autoload) {
+        if (file_exists($autoload)) {
+            require_once $autoload;
+            if (class_exists('PhpParser\ParserFactory')) {
+                return;
+            }
+        }
+    }
+
+    // Fallback: download PHP-Parser
+    $version = "5.6.1";
+    $phpParserDir = __DIR__ . "/PHP-Parser-$version";
+    if (!is_dir($phpParserDir)) {
+        installPhpParser($version, $phpParserDir);
+    }
+
+    spl_autoload_register(static function (string $class) use ($phpParserDir) {
+        if (strpos($class, "PhpParser\\") === 0) {
+            $fileName = $phpParserDir . "/lib/" . str_replace("\\", "/", $class) . ".php";
+            require $fileName;
+        }
+    });
+}
+
+$optind = null;
+$options = getopt(
+    "fh",
+    [
+        "force-regeneration",
+        "parameter-stats",
+        "help",
+        "verify",
+        "verify-manual",
+        "replace-predefined-constants",
+        "generate-classsynopses",
+        "replace-classsynopses",
+        "generate-methodsynopses",
+        "replace-methodsynopses",
+        "generate-optimizer-info",
+    ],
+    $optind
+);
+
+$context = new Context;
+$printParameterStats = isset($options["parameter-stats"]);
+$verify = isset($options["verify"]);
+$verifyManual = isset($options["verify-manual"]);
+$replacePredefinedConstants = isset($options["replace-predefined-constants"]);
+$generateClassSynopses = isset($options["generate-classsynopses"]);
+$replaceClassSynopses = isset($options["replace-classsynopses"]);
+$generateMethodSynopses = isset($options["generate-methodsynopses"]);
+$replaceMethodSynopses = isset($options["replace-methodsynopses"]);
+$generateOptimizerInfo = isset($options["generate-optimizer-info"]);
+$context->forceRegeneration = isset($options["f"]) || isset($options["force-regeneration"]);
+$context->forceParse = $context->forceRegeneration || $printParameterStats || $verify || $verifyManual || $replacePredefinedConstants || $generateClassSynopses || $generateOptimizerInfo || $replaceClassSynopses || $generateMethodSynopses || $replaceMethodSynopses;
+
+if (isset($options["h"]) || isset($options["help"])) {
+    die("\nUsage: gen_stub.php [ -f | --force-regeneration ] [ --replace-predefined-constants ] [ --generate-classsynopses ] [ --replace-classsynopses ] [ --generate-methodsynopses ] [ --replace-methodsynopses ] [ --parameter-stats ] [ --verify ]  [ --verify-manual ] [ --generate-optimizer-info ] [ -h | --help ] [ name.stub.php | directory ] [ directory ]\n\n");
+}
+
+$locations = array_slice($argv, $optind);
+$locationCount = count($locations);
+if ($replacePredefinedConstants && $locationCount < 2) {
+    die("At least one source stub path and a target manual directory has to be provided:\n./build/gen_stub.php --replace-predefined-constants ./ ../doc-en/\n");
+}
+if ($replaceClassSynopses && $locationCount < 2) {
+    die("At least one source stub path and a target manual directory has to be provided:\n./build/gen_stub.php --replace-classsynopses ./ ../doc-en/\n");
+}
+if ($generateMethodSynopses && $locationCount < 2) {
+    die("At least one source stub path and a target manual directory has to be provided:\n./build/gen_stub.php --generate-methodsynopses ./ ../doc-en/\n");
+}
+if ($replaceMethodSynopses && $locationCount < 2) {
+    die("At least one source stub path and a target manual directory has to be provided:\n./build/gen_stub.php --replace-methodsynopses ./ ../doc-en/\n");
+}
+if ($verifyManual && $locationCount < 2) {
+    die("At least one source stub path and a target manual directory has to be provided:\n./build/gen_stub.php --verify-manual ./ ../doc-en/\n");
+}
+$manualTarget = null;
+if ($replacePredefinedConstants || $replaceClassSynopses || $generateMethodSynopses || $replaceMethodSynopses || $verifyManual) {
+    $manualTarget = array_pop($locations);
+}
+if ($locations === []) {
+    $locations = ['.'];
+}
+
+$fileInfos = [];
+foreach (array_unique($locations) as $location) {
+    if (is_file($location)) {
+        // Generate single file.
+        $fileInfo = processStubFile($location, $context);
+        if ($fileInfo) {
+            $fileInfos[] = $fileInfo;
+        }
+    } else if (is_dir($location)) {
+        array_push($fileInfos, ...processDirectory($location, $context));
+    } else {
+        echo "$location is neither a file nor a directory.\n";
+        exit(1);
+    }
+}
+
+if ($printParameterStats) {
+    $parameterStats = [];
+
+    foreach ($fileInfos as $fileInfo) {
+        foreach ($fileInfo->getAllFuncInfos() as $funcInfo) {
+            foreach ($funcInfo->args as $argInfo) {
+                if (!isset($parameterStats[$argInfo->name])) {
+                    $parameterStats[$argInfo->name] = 0;
+                }
+                $parameterStats[$argInfo->name]++;
+            }
+        }
+    }
+
+    arsort($parameterStats);
+    echo json_encode($parameterStats, JSON_PRETTY_PRINT), "\n";
+}
+
+/** @var array<string, ClassInfo> $classMap */
+$classMap = [];
+/** @var array<string, FuncInfo> $funcMap */
+$funcMap = [];
+/** @var array<string, FuncInfo> $aliasMap */
+$aliasMap = [];
+
+/** @var array<string, ConstInfo> $undocumentedConstMap */
+$undocumentedConstMap = [];
+/** @var array<string, ClassInfo> $undocumentedClassMap */
+$undocumentedClassMap = [];
+/** @var array<string, FuncInfo> $undocumentedFuncMap */
+$undocumentedFuncMap = [];
+/** @var array<int, string> $methodSynopsisWarnings */
+$methodSynopsisWarnings = [];
+
+foreach ($fileInfos as $fileInfo) {
+    foreach ($fileInfo->getAllFuncInfos() as $funcInfo) {
+        $funcMap[$funcInfo->name->__toString()] = $funcInfo;
+
+        // TODO: Don't use aliasMap for methodsynopsis?
+        if ($funcInfo->aliasType === "alias") {
+            $aliasMap[$funcInfo->alias->__toString()] = $funcInfo;
+        }
+    }
+
+    foreach ($fileInfo->classInfos as $classInfo) {
+        $classMap[$classInfo->name->__toString()] = $classInfo;
+
+        if ($classInfo->alias !== null) {
+            $classMap[$classInfo->alias] = $classInfo;
+        }
+    }
+}
+
+if ($verify) {
+    $errors = [];
+
+    foreach ($funcMap as $aliasFunc) {
+        if (!$aliasFunc->alias || $aliasFunc->aliasType !== "alias") {
+            continue;
+        }
+
+        if (!isset($funcMap[$aliasFunc->alias->__toString()])) {
+            $errors[] = "Aliased function {$aliasFunc->alias}() cannot be found";
+            continue;
+        }
+
+        if (!$aliasFunc->verify) {
+            continue;
+        }
+
+        $aliasedFunc = $funcMap[$aliasFunc->alias->__toString()];
+        $aliasedArgs = $aliasedFunc->args;
+        $aliasArgs = $aliasFunc->args;
+
+        if ($aliasFunc->isInstanceMethod() !== $aliasedFunc->isInstanceMethod()) {
+            if ($aliasFunc->isInstanceMethod()) {
+                $aliasedArgs = array_slice($aliasedArgs, 1);
+            }
+
+            if ($aliasedFunc->isInstanceMethod()) {
+                $aliasArgs = array_slice($aliasArgs, 1);
+            }
+        }
+
+        array_map(
+            function (?ArgInfo $aliasArg, ?ArgInfo $aliasedArg) use ($aliasFunc, $aliasedFunc, &$errors) {
+                if ($aliasArg === null) {
+                    assert($aliasedArg !== null);
+                    $errors[] = "{$aliasFunc->name}(): Argument \$$aliasedArg->name of aliased function {$aliasedFunc->name}() is missing";
+                    return null;
+                }
+
+                if ($aliasedArg === null) {
+                    $errors[] = "{$aliasedFunc->name}(): Argument \$$aliasArg->name of alias function {$aliasFunc->name}() is missing";
+                    return null;
+                }
+
+                if ($aliasArg->name !== $aliasedArg->name) {
+                    $errors[] = "{$aliasFunc->name}(): Argument \$$aliasArg->name and argument \$$aliasedArg->name of aliased function {$aliasedFunc->name}() must have the same name";
+                    return null;
+                }
+
+                if ($aliasArg->type != $aliasedArg->type) {
+                    $errors[] = "{$aliasFunc->name}(): Argument \$$aliasArg->name and argument \$$aliasedArg->name of aliased function {$aliasedFunc->name}() must have the same type";
+                }
+
+                if ($aliasArg->defaultValue !== $aliasedArg->defaultValue) {
+                    $errors[] = "{$aliasFunc->name}(): Argument \$$aliasArg->name and argument \$$aliasedArg->name of aliased function {$aliasedFunc->name}() must have the same default value";
+                }
+            },
+            $aliasArgs,
+            $aliasedArgs
+        );
+
+        $aliasedReturn = $aliasedFunc->return;
+        $aliasReturn = $aliasFunc->return;
+
+        if (!$aliasedFunc->name->isConstructor() && !$aliasFunc->name->isConstructor()) {
+            $aliasedReturnType = $aliasedReturn->type ?? $aliasedReturn->phpDocType;
+            $aliasReturnType = $aliasReturn->type ?? $aliasReturn->phpDocType;
+            if ($aliasReturnType != $aliasedReturnType) {
+                $errors[] = "{$aliasFunc->name}() and {$aliasedFunc->name}() must have the same return type";
+            }
+        }
+
+        $aliasedPhpDocReturnType = $aliasedReturn->phpDocType;
+        $aliasPhpDocReturnType = $aliasReturn->phpDocType;
+        if ($aliasedPhpDocReturnType != $aliasPhpDocReturnType && $aliasedPhpDocReturnType != $aliasReturn->type && $aliasPhpDocReturnType != $aliasedReturn->type) {
+            $errors[] = "{$aliasFunc->name}() and {$aliasedFunc->name}() must have the same PHPDoc return type";
+        }
+    }
+
+    echo implode("\n", $errors);
+    if (!empty($errors)) {
+        echo "\n";
+        exit(1);
+    }
+}
+
+if ($replacePredefinedConstants || $verifyManual) {
+    $predefinedConstants = replacePredefinedConstants($manualTarget, $context->allConstInfos, $undocumentedConstMap);
+
+    if ($replacePredefinedConstants) {
+        foreach ($predefinedConstants as $filename => $content) {
+            reportFilePutContents($filename, $content);
+        }
+    }
+}
+
+if ($generateClassSynopses) {
+    $classSynopsesDirectory = getcwd() . "/classsynopses";
+
+    $classSynopses = generateClassSynopses($classMap, $context->allConstInfos);
+    if (!empty($classSynopses)) {
+        if (!file_exists($classSynopsesDirectory)) {
+            mkdir($classSynopsesDirectory);
+        }
+
+        foreach ($classSynopses as $filename => $content) {
+            reportFilePutContents("$classSynopsesDirectory/$filename", $content);
+        }
+    }
+}
+
+if ($replaceClassSynopses || $verifyManual) {
+    $classSynopses = replaceClassSynopses($manualTarget, $classMap, $context->allConstInfos, $undocumentedClassMap);
+
+    if ($replaceClassSynopses) {
+        foreach ($classSynopses as $filename => $content) {
+            reportFilePutContents($filename, $content);
+        }
+    }
+}
+
+if ($generateMethodSynopses) {
+    $methodSynopses = generateMethodSynopses($funcMap);
+    if (!file_exists($manualTarget)) {
+        mkdir($manualTarget);
+    }
+
+    foreach ($methodSynopses as $filename => $content) {
+        $path = "$manualTarget/$filename";
+
+        if (!file_exists($path)) {
+            if (!file_exists(dirname($path))) {
+                mkdir(dirname($path));
+            }
+
+            reportFilePutContents($path, $content);
+        }
+    }
+}
+
+if ($replaceMethodSynopses || $verifyManual) {
+    $methodSynopses = replaceMethodSynopses($manualTarget, $funcMap, $verifyManual, $methodSynopsisWarnings, $undocumentedFuncMap);
+
+    if ($replaceMethodSynopses) {
+        foreach ($methodSynopses as $filename => $content) {
+            reportFilePutContents($filename, $content);
+        }
+    }
+}
+
+if ($generateOptimizerInfo) {
+    $filename = dirname(__FILE__, 2) . "/Zend/Optimizer/zend_func_infos.h";
+    $optimizerInfo = generateOptimizerInfo($funcMap);
+
+    reportFilePutContents($filename, $optimizerInfo);
+}
+
+if ($verifyManual) {
+    foreach ($undocumentedConstMap as $constName => $info) {
+        if ($info->name instanceof ClassConstName || $info->isUndocumentable) {
+            continue;
+        }
+
+        echo "Warning: Missing predefined constant for $constName\n";
+    }
+
+    foreach ($methodSynopsisWarnings as $warning) {
+        echo "Warning: $warning\n";
+    }
+
+    foreach ($undocumentedClassMap as $className => $info) {
+        if (!$info->isUndocumentable) {
+            echo "Warning: Missing class synopsis for $className\n";
+        }
+    }
+
+    foreach ($undocumentedFuncMap as $functionName => $info) {
+        if (!$info->isUndocumentable) {
+            echo "Warning: Missing method synopsis for $functionName()\n";
+        }
+    }
+}

--- a/ort.stub.php
+++ b/ort.stub.php
@@ -1,0 +1,601 @@
+<?php
+
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
+
+namespace ORT {
+    /**
+     * @var int
+     * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
+     */
+    const TENSOR_UNDEFINED = UNKNOWN;
+
+    interface Tensor
+    {
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
+         */
+        public const UNDEFINED = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16
+         */
+        public const FLOAT16 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT32
+         */
+        public const FLOAT32 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT64
+         */
+        public const FLOAT64 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8
+         */
+        public const UINT8 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8
+         */
+        public const INT8 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16
+         */
+        public const UINT16 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16
+         */
+        public const INT16 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32
+         */
+        public const UINT32 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32
+         */
+        public const INT32 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64
+         */
+        public const INT64 = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL
+         */
+        public const BOOL = UNKNOWN;
+
+        public function isPersistent(): bool;
+
+        public function getName(): ?string;
+
+        public function getType(): int;
+
+        public function getTypeName(): string;
+
+        public function getShape(): array;
+
+        public function getSlice(array $start, array $end, array $axis = []): Tensor;
+
+        public function getData(int $offset = 0, int $depth = 0): array;
+
+        public function transpose(?array $axis = null): Tensor;
+    }
+
+    /**
+     * @not-serializable
+     */
+    class Model
+    {
+        public function __construct(
+            string $name,
+            string $source = '',
+            bool $array = false,
+            ?Options $options = null
+        ) {}
+
+        public static function unload(string $name): bool {}
+
+        public function getName(): string {}
+
+        public function getFile(): string {}
+
+        public function getInput(int $index): string {}
+
+        public function getInputCount(): int {}
+
+        /** @return \ORT\Model\Iterator */
+        public function getInputIterator(): Model\Iterator {}
+
+        public function getOutput(int $index): string {}
+
+        public function getOutputCount(): int {}
+
+        /** @return \ORT\Model\Iterator */
+        public function getOutputIterator(): Model\Iterator {}
+
+        public function getMeta(string $property): mixed {}
+    }
+
+    /**
+     * @not-serializable
+     */
+    class Runtime
+    {
+        public function __construct(Model $model) {}
+
+        public function run(array $input): mixed {}
+    }
+
+    /**
+     * @not-serializable
+     */
+    class Options
+    {
+        /**
+         * @var int
+         * @cvalue ORT_LOGGING_LEVEL_VERBOSE
+         */
+        public const LVERBOSE = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_LOGGING_LEVEL_INFO
+         */
+        public const LINFO = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_LOGGING_LEVEL_WARNING
+         */
+        public const LWARNING = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_LOGGING_LEVEL_ERROR
+         */
+        public const LERROR = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_LOGGING_LEVEL_FATAL
+         */
+        public const LFATAL = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_SEQUENTIAL
+         */
+        public const ESEQUENTIAL = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_PARALLEL
+         */
+        public const EPARALLEL = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_DISABLE_ALL
+         */
+        public const ONONE = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_ENABLE_BASIC
+         */
+        public const OBASIC = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_ENABLE_EXTENDED
+         */
+        public const OEXTENDED = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_ENABLE_ALL
+         */
+        public const OALL = UNKNOWN;
+
+        public function __construct() {}
+
+        public function setExecutionMode(int $mode): void {}
+
+        public function setGraphOptimization(int $optimization): void {}
+
+        public function setLogId(string $id): void {}
+
+        public function setLogSeverity(int $severity): void {}
+
+        public function setLogVerbosity(int $verbosity): void {}
+    }
+}
+
+namespace ORT\Tensor {
+    /**
+     * @not-serializable
+     */
+    class Persistent implements \ORT\Tensor
+    {
+        public function __construct(
+            string $name,
+            array $shape = [],
+            array|object $data = [],
+            int $type = \ORT\Tensor::FLOAT32
+        ) {}
+
+        public static function from(string $name, array $data, int $type): \ORT\Tensor {}
+
+        public function isPersistent(): bool {}
+
+        public function getName(): ?string {}
+
+        public function getType(): int {}
+
+        public function getTypeName(): string {}
+
+        public function getShape(): array {}
+
+        public function getSlice(array $start, array $end, array $axis = []): \ORT\Tensor {}
+
+        public function getData(int $offset = 0, int $depth = 0): array {}
+
+        public function transpose(?array $axis = null): \ORT\Tensor {}
+    }
+
+    /**
+     * @not-serializable
+     */
+    class Transient implements \ORT\Tensor
+    {
+        public function __construct(
+            array $shape,
+            array|object $data,
+            int $type = \ORT\Tensor::FLOAT32
+        ) {}
+
+        public static function from(array $data, int $type): \ORT\Tensor {}
+
+        public function isPersistent(): bool {}
+
+        public function getName(): ?string {}
+
+        public function getType(): int {}
+
+        public function getTypeName(): string {}
+
+        public function getShape(): array {}
+
+        public function getSlice(array $start, array $end, array $axis = []): \ORT\Tensor {}
+
+        public function getData(int $offset = 0, int $depth = 0): array {}
+
+        public function transpose(?array $axis = null): \ORT\Tensor {}
+    }
+
+    /**
+     * Base class for tensor data generators.
+     * Implement __invoke() to provide custom generation logic.
+     */
+    abstract class Generator
+    {
+        abstract public function __invoke(): mixed;
+    }
+}
+
+namespace ORT\Tensor\Generator {
+    /**
+     * Random number generator for tensors.
+     * Generates random values within specified bounds based on tensor type.
+     */
+    class Random extends \ORT\Tensor\Generator
+    {
+        public function __construct(int $type, int|float $min = 0, int|float $max = 1) {}
+
+        public function __invoke(): mixed {}
+    }
+}
+
+namespace ORT\Model {
+    /**
+     * Iterator for model input/output names.
+     */
+    class Iterator implements \Iterator
+    {
+        public function current(): string {}
+
+        public function key(): int {}
+
+        public function next(): void {}
+
+        public function rewind(): void {}
+
+        public function valid(): bool {}
+    }
+}
+
+namespace ORT\Math {
+    /**
+     * Schema for type promotion in mathematical operations.
+     */
+    final class Schema
+    {
+        /**
+         * @var int
+         * @cvalue ORT_MATH_PROMOTION_SCHEMA_KIND_BINARY
+         */
+        public const BINARY = UNKNOWN;
+
+        /**
+         * @var int
+         * @cvalue ORT_MATH_PROMOTION_SCHEMA_KIND_UNARY
+         */
+        public const UNARY = UNKNOWN;
+
+        public function __construct(string $symbol) {}
+
+        public function getSymbol(): ?string {}
+
+        public function getKind(): int {}
+
+        public function resolve(int ...$types): int {}
+    }
+
+    // -------------------------------------------------------------------------
+    // Arithmetic Operations
+    // -------------------------------------------------------------------------
+
+    function add(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function subtract(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function multiply(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function divide(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function mod(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function pow(\ORT\Tensor $tensor_a, \ORT\Tensor|int|float $tensor_b_or_scalar): \ORT\Tensor {}
+
+    function neg(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function recip(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function abs(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function sign(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Exponential and Logarithmic Functions
+    // -------------------------------------------------------------------------
+
+    function exp(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function exp2(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function log(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function log2(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function log10(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Power and Root Functions
+    // -------------------------------------------------------------------------
+
+    function sqrt(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function cbrt(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Trigonometric Functions
+    // -------------------------------------------------------------------------
+
+    function sin(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function cos(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function tan(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function asin(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function acos(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function atan(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arcsin(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arccos(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arctan(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Hyperbolic Functions
+    // -------------------------------------------------------------------------
+
+    function sinh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function cosh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function tanh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arcsinh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arccosh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function arctanh(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Rounding Functions
+    // -------------------------------------------------------------------------
+
+    function ceil(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function floor(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function round(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function trunc(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Matrix Operations
+    // -------------------------------------------------------------------------
+
+    function matmul(\ORT\Tensor $matrix_a, \ORT\Tensor $matrix_b): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Type Conversion
+    // -------------------------------------------------------------------------
+
+    function cast(int $type, \ORT\Tensor $tensor): \ORT\Tensor {}
+
+    // -------------------------------------------------------------------------
+    // Scaling and Backend Information
+    // -------------------------------------------------------------------------
+
+    function scale(int $cores, callable $code, int $threshold = 0): mixed {}
+
+    function backend(): array|false {}
+}
+
+namespace ORT\Math\reduce\tensor {
+    function min(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function max(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function mean(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function sum(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function argmax(\ORT\Tensor $tensor): \ORT\Tensor {}
+
+    function argmin(\ORT\Tensor $tensor): \ORT\Tensor {}
+}
+
+namespace ORT\Math\reduce\axis {
+    function min(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+
+    function max(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+
+    function mean(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+
+    function sum(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+
+    function argmax(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+
+    function argmin(\ORT\Tensor $tensor, int $axis, bool $keepdims = false): \ORT\Tensor {}
+}
+
+namespace ORT\Math\reduce {
+    function dot(\ORT\Tensor $tensor_a, \ORT\Tensor $tensor_b): \ORT\Tensor {}
+}
+
+namespace ORT\Math\transform\axis {
+    function softmax(\ORT\Tensor $tensor, int $axis): \ORT\Tensor {}
+}
+
+namespace ORT\Math\scale {
+    function cores(bool $max = false): int {}
+
+    function threshold(bool $default = false): int {}
+}
+
+namespace ORT\Math\backend {
+    function cpu(): string|false {}
+
+    function gpu(): string|false {}
+}
+
+// =============================================================================
+// Exception Hierarchy
+// =============================================================================
+
+namespace ORT\Status {
+    class Error extends \Error {}
+
+    class SafetyError extends Error {}
+
+    class ScalingError extends Error {}
+}
+
+namespace ORT\Status\Tensor {
+    class Error extends \ORT\Status\Error {}
+
+    class NotFound extends \ORT\Status\Tensor\Error {}
+
+    class InvalidType extends \ORT\Status\Tensor\Error {}
+
+    class InvalidShape extends \ORT\Status\Tensor\Error {}
+
+    class InvalidData extends \ORT\Status\Tensor\Error {}
+
+    class InvalidMemory extends \ORT\Status\Tensor\Error {}
+
+    class InvalidOffset extends \ORT\Status\Tensor\Error {}
+
+    class InvalidAccess extends \ORT\Status\Tensor\Error {}
+}
+
+namespace ORT\Status\Math {
+    class Error extends \ORT\Status\Error {}
+
+    class InvalidShape extends \ORT\Status\Math\Error {}
+
+    class InvalidType extends \ORT\Status\Math\Error {}
+
+    class InvalidBroadcast extends \ORT\Status\Math\Error {}
+
+    class InvalidOperation extends \ORT\Status\Math\Error {}
+
+    class DivisionByZero extends \ORT\Status\Math\Error {}
+}
+
+namespace ORT\Status\Model {
+    class Error extends \ORT\Status\Error {}
+
+    class InvalidMemory extends \ORT\Status\Model\Error {}
+
+    class InvalidOptions extends \ORT\Status\Model\Error {}
+
+    class InvalidModel extends \ORT\Status\Model\Error {}
+
+    class InvalidInput extends \ORT\Status\Model\Error {}
+
+    class InvalidOutput extends \ORT\Status\Model\Error {}
+
+    class InvalidIndex extends \ORT\Status\Model\Error {}
+
+    class InvalidFile extends \ORT\Status\Model\Error {}
+
+    class RuntimeException extends \ORT\Status\Model\Error {}
+}
+
+namespace ORT\Status\Schema {
+    class Error extends \ORT\Status\Error {}
+
+    class InvalidSymbol extends \ORT\Status\Schema\Error {}
+
+    class InvalidArguments extends \ORT\Status\Schema\Error {}
+}

--- a/ort_arginfo.h
+++ b/ort_arginfo.h
@@ -1,0 +1,1599 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 53c3883a661aebd2dd19193025636671e84afc6f */
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_add, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor_a, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, tensor_b_or_scalar, ORT\\Tensor, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ORT_Math_subtract arginfo_ORT_Math_add
+
+#define arginfo_ORT_Math_multiply arginfo_ORT_Math_add
+
+#define arginfo_ORT_Math_divide arginfo_ORT_Math_add
+
+#define arginfo_ORT_Math_mod arginfo_ORT_Math_add
+
+#define arginfo_ORT_Math_pow arginfo_ORT_Math_add
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_neg, 0, 1, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor, ORT\\Tensor, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ORT_Math_recip arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_abs arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_sign arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_exp arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_exp2 arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_log arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_log2 arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_log10 arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_sqrt arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_cbrt arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_sin arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_cos arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_tan arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_asin arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_acos arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_atan arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arcsin arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arccos arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arctan arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_sinh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_cosh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_tanh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arcsinh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arccosh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_arctanh arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_ceil arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_floor arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_round arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_trunc arginfo_ORT_Math_neg
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_matmul, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, matrix_a, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, matrix_b, ORT\\Tensor, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_cast, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor, ORT\\Tensor, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ORT_Math_scale, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, cores, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, code, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, threshold, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ORT_Math_backend, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ORT_Math_reduce_tensor_min arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_reduce_tensor_max arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_reduce_tensor_mean arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_reduce_tensor_sum arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_reduce_tensor_argmax arginfo_ORT_Math_neg
+
+#define arginfo_ORT_Math_reduce_tensor_argmin arginfo_ORT_Math_neg
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_reduce_axis_min, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, axis, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, keepdims, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+#define arginfo_ORT_Math_reduce_axis_max arginfo_ORT_Math_reduce_axis_min
+
+#define arginfo_ORT_Math_reduce_axis_mean arginfo_ORT_Math_reduce_axis_min
+
+#define arginfo_ORT_Math_reduce_axis_sum arginfo_ORT_Math_reduce_axis_min
+
+#define arginfo_ORT_Math_reduce_axis_argmax arginfo_ORT_Math_reduce_axis_min
+
+#define arginfo_ORT_Math_reduce_axis_argmin arginfo_ORT_Math_reduce_axis_min
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_reduce_dot, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor_a, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor_b, ORT\\Tensor, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_ORT_Math_transform_axis_softmax, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_OBJ_INFO(0, tensor, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, axis, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ORT_Math_scale_cores, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, max, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ORT_Math_scale_threshold, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, default, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ORT_Math_backend_cpu, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ORT_Math_backend_gpu arginfo_ORT_Math_backend_cpu
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_isPersistent, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_getName, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_getType, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_getTypeName, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_getShape, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ORT_Tensor_getSlice, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, start, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, end, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, axis, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_getData, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, depth, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ORT_Tensor_transpose, 0, 0, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, axis, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Model___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, source, IS_STRING, 0, "\'\'")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, array, _IS_BOOL, 0, "false")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, options, ORT\\Options, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Model_unload, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Model_getName arginfo_class_ORT_Tensor_getTypeName
+
+#define arginfo_class_ORT_Model_getFile arginfo_class_ORT_Tensor_getTypeName
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Model_getInput, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Model_getInputCount arginfo_class_ORT_Tensor_getType
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ORT_Model_getInputIterator, 0, 0, ORT\\Model\\Iterator, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Model_getOutput arginfo_class_ORT_Model_getInput
+
+#define arginfo_class_ORT_Model_getOutputCount arginfo_class_ORT_Tensor_getType
+
+#define arginfo_class_ORT_Model_getOutputIterator arginfo_class_ORT_Model_getInputIterator
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Model_getMeta, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, property, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Runtime___construct, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, model, ORT\\Model, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Runtime_run, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Options___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Options_setExecutionMode, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Options_setGraphOptimization, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, optimization, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Options_setLogId, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Options_setLogSeverity, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, severity, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Options_setLogVerbosity, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, verbosity, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Tensor_Persistent___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, shape, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_MASK(0, data, MAY_BE_ARRAY|MAY_BE_OBJECT, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "ORT\\Tensor::FLOAT32")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ORT_Tensor_Persistent_from, 0, 3, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Tensor_Persistent_isPersistent arginfo_class_ORT_Tensor_isPersistent
+
+#define arginfo_class_ORT_Tensor_Persistent_getName arginfo_class_ORT_Tensor_getName
+
+#define arginfo_class_ORT_Tensor_Persistent_getType arginfo_class_ORT_Tensor_getType
+
+#define arginfo_class_ORT_Tensor_Persistent_getTypeName arginfo_class_ORT_Tensor_getTypeName
+
+#define arginfo_class_ORT_Tensor_Persistent_getShape arginfo_class_ORT_Tensor_getShape
+
+#define arginfo_class_ORT_Tensor_Persistent_getSlice arginfo_class_ORT_Tensor_getSlice
+
+#define arginfo_class_ORT_Tensor_Persistent_getData arginfo_class_ORT_Tensor_getData
+
+#define arginfo_class_ORT_Tensor_Persistent_transpose arginfo_class_ORT_Tensor_transpose
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Tensor_Transient___construct, 0, 0, 2)
+	ZEND_ARG_TYPE_INFO(0, shape, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, data, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "ORT\\Tensor::FLOAT32")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ORT_Tensor_Transient_from, 0, 2, ORT\\Tensor, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Tensor_Transient_isPersistent arginfo_class_ORT_Tensor_isPersistent
+
+#define arginfo_class_ORT_Tensor_Transient_getName arginfo_class_ORT_Tensor_getName
+
+#define arginfo_class_ORT_Tensor_Transient_getType arginfo_class_ORT_Tensor_getType
+
+#define arginfo_class_ORT_Tensor_Transient_getTypeName arginfo_class_ORT_Tensor_getTypeName
+
+#define arginfo_class_ORT_Tensor_Transient_getShape arginfo_class_ORT_Tensor_getShape
+
+#define arginfo_class_ORT_Tensor_Transient_getSlice arginfo_class_ORT_Tensor_getSlice
+
+#define arginfo_class_ORT_Tensor_Transient_getData arginfo_class_ORT_Tensor_getData
+
+#define arginfo_class_ORT_Tensor_Transient_transpose arginfo_class_ORT_Tensor_transpose
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Tensor_Generator___invoke, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Tensor_Generator_Random___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_MASK(0, min, MAY_BE_LONG|MAY_BE_DOUBLE, "0")
+	ZEND_ARG_TYPE_MASK(0, max, MAY_BE_LONG|MAY_BE_DOUBLE, "1")
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Tensor_Generator_Random___invoke arginfo_class_ORT_Tensor_Generator___invoke
+
+#define arginfo_class_ORT_Model_Iterator_current arginfo_class_ORT_Tensor_getTypeName
+
+#define arginfo_class_ORT_Model_Iterator_key arginfo_class_ORT_Tensor_getType
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Model_Iterator_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Model_Iterator_rewind arginfo_class_ORT_Model_Iterator_next
+
+#define arginfo_class_ORT_Model_Iterator_valid arginfo_class_ORT_Tensor_isPersistent
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORT_Math_Schema___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, symbol, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ORT_Math_Schema_getSymbol arginfo_class_ORT_Tensor_getName
+
+#define arginfo_class_ORT_Math_Schema_getKind arginfo_class_ORT_Tensor_getType
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORT_Math_Schema_resolve, 0, 0, IS_LONG, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, types, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_FUNCTION(ORT_Math_add);
+ZEND_FUNCTION(ORT_Math_subtract);
+ZEND_FUNCTION(ORT_Math_multiply);
+ZEND_FUNCTION(ORT_Math_divide);
+ZEND_FUNCTION(ORT_Math_mod);
+ZEND_FUNCTION(ORT_Math_pow);
+ZEND_FUNCTION(ORT_Math_neg);
+ZEND_FUNCTION(ORT_Math_recip);
+ZEND_FUNCTION(ORT_Math_abs);
+ZEND_FUNCTION(ORT_Math_sign);
+ZEND_FUNCTION(ORT_Math_exp);
+ZEND_FUNCTION(ORT_Math_exp2);
+ZEND_FUNCTION(ORT_Math_log);
+ZEND_FUNCTION(ORT_Math_log2);
+ZEND_FUNCTION(ORT_Math_log10);
+ZEND_FUNCTION(ORT_Math_sqrt);
+ZEND_FUNCTION(ORT_Math_cbrt);
+ZEND_FUNCTION(ORT_Math_sin);
+ZEND_FUNCTION(ORT_Math_cos);
+ZEND_FUNCTION(ORT_Math_tan);
+ZEND_FUNCTION(ORT_Math_asin);
+ZEND_FUNCTION(ORT_Math_acos);
+ZEND_FUNCTION(ORT_Math_atan);
+ZEND_FUNCTION(ORT_Math_arcsin);
+ZEND_FUNCTION(ORT_Math_arccos);
+ZEND_FUNCTION(ORT_Math_arctan);
+ZEND_FUNCTION(ORT_Math_sinh);
+ZEND_FUNCTION(ORT_Math_cosh);
+ZEND_FUNCTION(ORT_Math_tanh);
+ZEND_FUNCTION(ORT_Math_arcsinh);
+ZEND_FUNCTION(ORT_Math_arccosh);
+ZEND_FUNCTION(ORT_Math_arctanh);
+ZEND_FUNCTION(ORT_Math_ceil);
+ZEND_FUNCTION(ORT_Math_floor);
+ZEND_FUNCTION(ORT_Math_round);
+ZEND_FUNCTION(ORT_Math_trunc);
+ZEND_FUNCTION(ORT_Math_matmul);
+ZEND_FUNCTION(ORT_Math_cast);
+ZEND_FUNCTION(ORT_Math_scale);
+ZEND_FUNCTION(ORT_Math_backend);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_min);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_max);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_mean);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_sum);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_argmax);
+ZEND_FUNCTION(ORT_Math_reduce_tensor_argmin);
+ZEND_FUNCTION(ORT_Math_reduce_axis_min);
+ZEND_FUNCTION(ORT_Math_reduce_axis_max);
+ZEND_FUNCTION(ORT_Math_reduce_axis_mean);
+ZEND_FUNCTION(ORT_Math_reduce_axis_sum);
+ZEND_FUNCTION(ORT_Math_reduce_axis_argmax);
+ZEND_FUNCTION(ORT_Math_reduce_axis_argmin);
+ZEND_FUNCTION(ORT_Math_reduce_dot);
+ZEND_FUNCTION(ORT_Math_transform_axis_softmax);
+ZEND_FUNCTION(ORT_Math_scale_cores);
+ZEND_FUNCTION(ORT_Math_scale_threshold);
+ZEND_FUNCTION(ORT_Math_backend_cpu);
+ZEND_FUNCTION(ORT_Math_backend_gpu);
+ZEND_METHOD(ORT_Model, __construct);
+ZEND_METHOD(ORT_Model, unload);
+ZEND_METHOD(ORT_Model, getName);
+ZEND_METHOD(ORT_Model, getFile);
+ZEND_METHOD(ORT_Model, getInput);
+ZEND_METHOD(ORT_Model, getInputCount);
+ZEND_METHOD(ORT_Model, getInputIterator);
+ZEND_METHOD(ORT_Model, getOutput);
+ZEND_METHOD(ORT_Model, getOutputCount);
+ZEND_METHOD(ORT_Model, getOutputIterator);
+ZEND_METHOD(ORT_Model, getMeta);
+ZEND_METHOD(ORT_Runtime, __construct);
+ZEND_METHOD(ORT_Runtime, run);
+ZEND_METHOD(ORT_Options, __construct);
+ZEND_METHOD(ORT_Options, setExecutionMode);
+ZEND_METHOD(ORT_Options, setGraphOptimization);
+ZEND_METHOD(ORT_Options, setLogId);
+ZEND_METHOD(ORT_Options, setLogSeverity);
+ZEND_METHOD(ORT_Options, setLogVerbosity);
+ZEND_METHOD(ORT_Tensor_Persistent, __construct);
+ZEND_METHOD(ORT_Tensor_Persistent, from);
+ZEND_METHOD(ORT_Tensor_Persistent, isPersistent);
+ZEND_METHOD(ORT_Tensor_Persistent, getName);
+ZEND_METHOD(ORT_Tensor_Persistent, getType);
+ZEND_METHOD(ORT_Tensor_Persistent, getTypeName);
+ZEND_METHOD(ORT_Tensor_Persistent, getShape);
+ZEND_METHOD(ORT_Tensor_Persistent, getSlice);
+ZEND_METHOD(ORT_Tensor_Persistent, getData);
+ZEND_METHOD(ORT_Tensor_Persistent, transpose);
+ZEND_METHOD(ORT_Tensor_Transient, __construct);
+ZEND_METHOD(ORT_Tensor_Transient, from);
+ZEND_METHOD(ORT_Tensor_Transient, isPersistent);
+ZEND_METHOD(ORT_Tensor_Transient, getName);
+ZEND_METHOD(ORT_Tensor_Transient, getType);
+ZEND_METHOD(ORT_Tensor_Transient, getTypeName);
+ZEND_METHOD(ORT_Tensor_Transient, getShape);
+ZEND_METHOD(ORT_Tensor_Transient, getSlice);
+ZEND_METHOD(ORT_Tensor_Transient, getData);
+ZEND_METHOD(ORT_Tensor_Transient, transpose);
+ZEND_METHOD(ORT_Tensor_Generator_Random, __construct);
+ZEND_METHOD(ORT_Tensor_Generator_Random, __invoke);
+ZEND_METHOD(ORT_Model_Iterator, current);
+ZEND_METHOD(ORT_Model_Iterator, key);
+ZEND_METHOD(ORT_Model_Iterator, next);
+ZEND_METHOD(ORT_Model_Iterator, rewind);
+ZEND_METHOD(ORT_Model_Iterator, valid);
+ZEND_METHOD(ORT_Math_Schema, __construct);
+ZEND_METHOD(ORT_Math_Schema, getSymbol);
+ZEND_METHOD(ORT_Math_Schema, getKind);
+ZEND_METHOD(ORT_Math_Schema, resolve);
+
+static const zend_function_entry ext_functions[] = {
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "add"), zif_ORT_Math_add, arginfo_ORT_Math_add, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "add"), zif_ORT_Math_add, arginfo_ORT_Math_add, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "subtract"), zif_ORT_Math_subtract, arginfo_ORT_Math_subtract, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "subtract"), zif_ORT_Math_subtract, arginfo_ORT_Math_subtract, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "multiply"), zif_ORT_Math_multiply, arginfo_ORT_Math_multiply, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "multiply"), zif_ORT_Math_multiply, arginfo_ORT_Math_multiply, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "divide"), zif_ORT_Math_divide, arginfo_ORT_Math_divide, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "divide"), zif_ORT_Math_divide, arginfo_ORT_Math_divide, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "mod"), zif_ORT_Math_mod, arginfo_ORT_Math_mod, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "mod"), zif_ORT_Math_mod, arginfo_ORT_Math_mod, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "pow"), zif_ORT_Math_pow, arginfo_ORT_Math_pow, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "pow"), zif_ORT_Math_pow, arginfo_ORT_Math_pow, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "neg"), zif_ORT_Math_neg, arginfo_ORT_Math_neg, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "neg"), zif_ORT_Math_neg, arginfo_ORT_Math_neg, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "recip"), zif_ORT_Math_recip, arginfo_ORT_Math_recip, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "recip"), zif_ORT_Math_recip, arginfo_ORT_Math_recip, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "abs"), zif_ORT_Math_abs, arginfo_ORT_Math_abs, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "abs"), zif_ORT_Math_abs, arginfo_ORT_Math_abs, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sign"), zif_ORT_Math_sign, arginfo_ORT_Math_sign, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sign"), zif_ORT_Math_sign, arginfo_ORT_Math_sign, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "exp"), zif_ORT_Math_exp, arginfo_ORT_Math_exp, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "exp"), zif_ORT_Math_exp, arginfo_ORT_Math_exp, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "exp2"), zif_ORT_Math_exp2, arginfo_ORT_Math_exp2, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "exp2"), zif_ORT_Math_exp2, arginfo_ORT_Math_exp2, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log"), zif_ORT_Math_log, arginfo_ORT_Math_log, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log"), zif_ORT_Math_log, arginfo_ORT_Math_log, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log2"), zif_ORT_Math_log2, arginfo_ORT_Math_log2, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log2"), zif_ORT_Math_log2, arginfo_ORT_Math_log2, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log10"), zif_ORT_Math_log10, arginfo_ORT_Math_log10, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "log10"), zif_ORT_Math_log10, arginfo_ORT_Math_log10, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sqrt"), zif_ORT_Math_sqrt, arginfo_ORT_Math_sqrt, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sqrt"), zif_ORT_Math_sqrt, arginfo_ORT_Math_sqrt, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cbrt"), zif_ORT_Math_cbrt, arginfo_ORT_Math_cbrt, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cbrt"), zif_ORT_Math_cbrt, arginfo_ORT_Math_cbrt, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sin"), zif_ORT_Math_sin, arginfo_ORT_Math_sin, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sin"), zif_ORT_Math_sin, arginfo_ORT_Math_sin, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cos"), zif_ORT_Math_cos, arginfo_ORT_Math_cos, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cos"), zif_ORT_Math_cos, arginfo_ORT_Math_cos, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "tan"), zif_ORT_Math_tan, arginfo_ORT_Math_tan, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "tan"), zif_ORT_Math_tan, arginfo_ORT_Math_tan, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "asin"), zif_ORT_Math_asin, arginfo_ORT_Math_asin, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "asin"), zif_ORT_Math_asin, arginfo_ORT_Math_asin, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "acos"), zif_ORT_Math_acos, arginfo_ORT_Math_acos, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "acos"), zif_ORT_Math_acos, arginfo_ORT_Math_acos, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "atan"), zif_ORT_Math_atan, arginfo_ORT_Math_atan, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "atan"), zif_ORT_Math_atan, arginfo_ORT_Math_atan, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arcsin"), zif_ORT_Math_arcsin, arginfo_ORT_Math_arcsin, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arcsin"), zif_ORT_Math_arcsin, arginfo_ORT_Math_arcsin, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arccos"), zif_ORT_Math_arccos, arginfo_ORT_Math_arccos, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arccos"), zif_ORT_Math_arccos, arginfo_ORT_Math_arccos, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arctan"), zif_ORT_Math_arctan, arginfo_ORT_Math_arctan, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arctan"), zif_ORT_Math_arctan, arginfo_ORT_Math_arctan, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sinh"), zif_ORT_Math_sinh, arginfo_ORT_Math_sinh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "sinh"), zif_ORT_Math_sinh, arginfo_ORT_Math_sinh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cosh"), zif_ORT_Math_cosh, arginfo_ORT_Math_cosh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cosh"), zif_ORT_Math_cosh, arginfo_ORT_Math_cosh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "tanh"), zif_ORT_Math_tanh, arginfo_ORT_Math_tanh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "tanh"), zif_ORT_Math_tanh, arginfo_ORT_Math_tanh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arcsinh"), zif_ORT_Math_arcsinh, arginfo_ORT_Math_arcsinh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arcsinh"), zif_ORT_Math_arcsinh, arginfo_ORT_Math_arcsinh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arccosh"), zif_ORT_Math_arccosh, arginfo_ORT_Math_arccosh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arccosh"), zif_ORT_Math_arccosh, arginfo_ORT_Math_arccosh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arctanh"), zif_ORT_Math_arctanh, arginfo_ORT_Math_arctanh, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "arctanh"), zif_ORT_Math_arctanh, arginfo_ORT_Math_arctanh, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "ceil"), zif_ORT_Math_ceil, arginfo_ORT_Math_ceil, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "ceil"), zif_ORT_Math_ceil, arginfo_ORT_Math_ceil, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "floor"), zif_ORT_Math_floor, arginfo_ORT_Math_floor, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "floor"), zif_ORT_Math_floor, arginfo_ORT_Math_floor, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "round"), zif_ORT_Math_round, arginfo_ORT_Math_round, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "round"), zif_ORT_Math_round, arginfo_ORT_Math_round, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "trunc"), zif_ORT_Math_trunc, arginfo_ORT_Math_trunc, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "trunc"), zif_ORT_Math_trunc, arginfo_ORT_Math_trunc, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "matmul"), zif_ORT_Math_matmul, arginfo_ORT_Math_matmul, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "matmul"), zif_ORT_Math_matmul, arginfo_ORT_Math_matmul, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cast"), zif_ORT_Math_cast, arginfo_ORT_Math_cast, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "cast"), zif_ORT_Math_cast, arginfo_ORT_Math_cast, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "scale"), zif_ORT_Math_scale, arginfo_ORT_Math_scale, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "scale"), zif_ORT_Math_scale, arginfo_ORT_Math_scale, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "backend"), zif_ORT_Math_backend, arginfo_ORT_Math_backend, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math", "backend"), zif_ORT_Math_backend, arginfo_ORT_Math_backend, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "min"), zif_ORT_Math_reduce_tensor_min, arginfo_ORT_Math_reduce_tensor_min, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "min"), zif_ORT_Math_reduce_tensor_min, arginfo_ORT_Math_reduce_tensor_min, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "max"), zif_ORT_Math_reduce_tensor_max, arginfo_ORT_Math_reduce_tensor_max, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "max"), zif_ORT_Math_reduce_tensor_max, arginfo_ORT_Math_reduce_tensor_max, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "mean"), zif_ORT_Math_reduce_tensor_mean, arginfo_ORT_Math_reduce_tensor_mean, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "mean"), zif_ORT_Math_reduce_tensor_mean, arginfo_ORT_Math_reduce_tensor_mean, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "sum"), zif_ORT_Math_reduce_tensor_sum, arginfo_ORT_Math_reduce_tensor_sum, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "sum"), zif_ORT_Math_reduce_tensor_sum, arginfo_ORT_Math_reduce_tensor_sum, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "argmax"), zif_ORT_Math_reduce_tensor_argmax, arginfo_ORT_Math_reduce_tensor_argmax, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "argmax"), zif_ORT_Math_reduce_tensor_argmax, arginfo_ORT_Math_reduce_tensor_argmax, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "argmin"), zif_ORT_Math_reduce_tensor_argmin, arginfo_ORT_Math_reduce_tensor_argmin, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\tensor", "argmin"), zif_ORT_Math_reduce_tensor_argmin, arginfo_ORT_Math_reduce_tensor_argmin, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "min"), zif_ORT_Math_reduce_axis_min, arginfo_ORT_Math_reduce_axis_min, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "min"), zif_ORT_Math_reduce_axis_min, arginfo_ORT_Math_reduce_axis_min, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "max"), zif_ORT_Math_reduce_axis_max, arginfo_ORT_Math_reduce_axis_max, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "max"), zif_ORT_Math_reduce_axis_max, arginfo_ORT_Math_reduce_axis_max, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "mean"), zif_ORT_Math_reduce_axis_mean, arginfo_ORT_Math_reduce_axis_mean, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "mean"), zif_ORT_Math_reduce_axis_mean, arginfo_ORT_Math_reduce_axis_mean, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "sum"), zif_ORT_Math_reduce_axis_sum, arginfo_ORT_Math_reduce_axis_sum, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "sum"), zif_ORT_Math_reduce_axis_sum, arginfo_ORT_Math_reduce_axis_sum, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "argmax"), zif_ORT_Math_reduce_axis_argmax, arginfo_ORT_Math_reduce_axis_argmax, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "argmax"), zif_ORT_Math_reduce_axis_argmax, arginfo_ORT_Math_reduce_axis_argmax, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "argmin"), zif_ORT_Math_reduce_axis_argmin, arginfo_ORT_Math_reduce_axis_argmin, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce\\axis", "argmin"), zif_ORT_Math_reduce_axis_argmin, arginfo_ORT_Math_reduce_axis_argmin, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce", "dot"), zif_ORT_Math_reduce_dot, arginfo_ORT_Math_reduce_dot, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\reduce", "dot"), zif_ORT_Math_reduce_dot, arginfo_ORT_Math_reduce_dot, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\transform\\axis", "softmax"), zif_ORT_Math_transform_axis_softmax, arginfo_ORT_Math_transform_axis_softmax, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\transform\\axis", "softmax"), zif_ORT_Math_transform_axis_softmax, arginfo_ORT_Math_transform_axis_softmax, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\scale", "cores"), zif_ORT_Math_scale_cores, arginfo_ORT_Math_scale_cores, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\scale", "cores"), zif_ORT_Math_scale_cores, arginfo_ORT_Math_scale_cores, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\scale", "threshold"), zif_ORT_Math_scale_threshold, arginfo_ORT_Math_scale_threshold, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\scale", "threshold"), zif_ORT_Math_scale_threshold, arginfo_ORT_Math_scale_threshold, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\backend", "cpu"), zif_ORT_Math_backend_cpu, arginfo_ORT_Math_backend_cpu, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\backend", "cpu"), zif_ORT_Math_backend_cpu, arginfo_ORT_Math_backend_cpu, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\backend", "gpu"), zif_ORT_Math_backend_gpu, arginfo_ORT_Math_backend_gpu, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("ORT\\Math\\backend", "gpu"), zif_ORT_Math_backend_gpu, arginfo_ORT_Math_backend_gpu, 0)
+#endif
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Tensor_methods[] = {
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("isPersistent", NULL, arginfo_class_ORT_Tensor_isPersistent, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("isPersistent", NULL, arginfo_class_ORT_Tensor_isPersistent, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getName", NULL, arginfo_class_ORT_Tensor_getName, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getName", NULL, arginfo_class_ORT_Tensor_getName, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getType", NULL, arginfo_class_ORT_Tensor_getType, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getType", NULL, arginfo_class_ORT_Tensor_getType, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getTypeName", NULL, arginfo_class_ORT_Tensor_getTypeName, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getTypeName", NULL, arginfo_class_ORT_Tensor_getTypeName, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getShape", NULL, arginfo_class_ORT_Tensor_getShape, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getShape", NULL, arginfo_class_ORT_Tensor_getShape, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getSlice", NULL, arginfo_class_ORT_Tensor_getSlice, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getSlice", NULL, arginfo_class_ORT_Tensor_getSlice, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getData", NULL, arginfo_class_ORT_Tensor_getData, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getData", NULL, arginfo_class_ORT_Tensor_getData, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("transpose", NULL, arginfo_class_ORT_Tensor_transpose, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("transpose", NULL, arginfo_class_ORT_Tensor_transpose, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Model_methods[] = {
+	ZEND_ME(ORT_Model, __construct, arginfo_class_ORT_Model___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, unload, arginfo_class_ORT_Model_unload, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(ORT_Model, getName, arginfo_class_ORT_Model_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getFile, arginfo_class_ORT_Model_getFile, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getInput, arginfo_class_ORT_Model_getInput, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getInputCount, arginfo_class_ORT_Model_getInputCount, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getInputIterator, arginfo_class_ORT_Model_getInputIterator, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getOutput, arginfo_class_ORT_Model_getOutput, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getOutputCount, arginfo_class_ORT_Model_getOutputCount, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getOutputIterator, arginfo_class_ORT_Model_getOutputIterator, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model, getMeta, arginfo_class_ORT_Model_getMeta, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Runtime_methods[] = {
+	ZEND_ME(ORT_Runtime, __construct, arginfo_class_ORT_Runtime___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Runtime, run, arginfo_class_ORT_Runtime_run, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Options_methods[] = {
+	ZEND_ME(ORT_Options, __construct, arginfo_class_ORT_Options___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Options, setExecutionMode, arginfo_class_ORT_Options_setExecutionMode, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Options, setGraphOptimization, arginfo_class_ORT_Options_setGraphOptimization, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Options, setLogId, arginfo_class_ORT_Options_setLogId, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Options, setLogSeverity, arginfo_class_ORT_Options_setLogSeverity, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Options, setLogVerbosity, arginfo_class_ORT_Options_setLogVerbosity, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Tensor_Persistent_methods[] = {
+	ZEND_ME(ORT_Tensor_Persistent, __construct, arginfo_class_ORT_Tensor_Persistent___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, from, arginfo_class_ORT_Tensor_Persistent_from, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(ORT_Tensor_Persistent, isPersistent, arginfo_class_ORT_Tensor_Persistent_isPersistent, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getName, arginfo_class_ORT_Tensor_Persistent_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getType, arginfo_class_ORT_Tensor_Persistent_getType, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getTypeName, arginfo_class_ORT_Tensor_Persistent_getTypeName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getShape, arginfo_class_ORT_Tensor_Persistent_getShape, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getSlice, arginfo_class_ORT_Tensor_Persistent_getSlice, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, getData, arginfo_class_ORT_Tensor_Persistent_getData, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Persistent, transpose, arginfo_class_ORT_Tensor_Persistent_transpose, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Tensor_Transient_methods[] = {
+	ZEND_ME(ORT_Tensor_Transient, __construct, arginfo_class_ORT_Tensor_Transient___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, from, arginfo_class_ORT_Tensor_Transient_from, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(ORT_Tensor_Transient, isPersistent, arginfo_class_ORT_Tensor_Transient_isPersistent, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getName, arginfo_class_ORT_Tensor_Transient_getName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getType, arginfo_class_ORT_Tensor_Transient_getType, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getTypeName, arginfo_class_ORT_Tensor_Transient_getTypeName, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getShape, arginfo_class_ORT_Tensor_Transient_getShape, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getSlice, arginfo_class_ORT_Tensor_Transient_getSlice, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, getData, arginfo_class_ORT_Tensor_Transient_getData, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Transient, transpose, arginfo_class_ORT_Tensor_Transient_transpose, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Tensor_Generator_methods[] = {
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__invoke", NULL, arginfo_class_ORT_Tensor_Generator___invoke, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__invoke", NULL, arginfo_class_ORT_Tensor_Generator___invoke, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Tensor_Generator_Random_methods[] = {
+	ZEND_ME(ORT_Tensor_Generator_Random, __construct, arginfo_class_ORT_Tensor_Generator_Random___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Tensor_Generator_Random, __invoke, arginfo_class_ORT_Tensor_Generator_Random___invoke, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Model_Iterator_methods[] = {
+	ZEND_ME(ORT_Model_Iterator, current, arginfo_class_ORT_Model_Iterator_current, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model_Iterator, key, arginfo_class_ORT_Model_Iterator_key, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model_Iterator, next, arginfo_class_ORT_Model_Iterator_next, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model_Iterator, rewind, arginfo_class_ORT_Model_Iterator_rewind, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Model_Iterator, valid, arginfo_class_ORT_Model_Iterator_valid, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_ORT_Math_Schema_methods[] = {
+	ZEND_ME(ORT_Math_Schema, __construct, arginfo_class_ORT_Math_Schema___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Math_Schema, getSymbol, arginfo_class_ORT_Math_Schema_getSymbol, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Math_Schema, getKind, arginfo_class_ORT_Math_Schema_getKind, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORT_Math_Schema, resolve, arginfo_class_ORT_Math_Schema_resolve, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static void register_ort_symbols(int module_number)
+{
+	REGISTER_LONG_CONSTANT("ORT\\TENSOR_UNDEFINED", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, CONST_PERSISTENT);
+}
+
+static zend_class_entry *register_class_ORT_Tensor(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT", "Tensor", class_ORT_Tensor_methods);
+	class_entry = zend_register_internal_interface(&ce);
+
+	zval const_UNDEFINED_value;
+	ZVAL_LONG(&const_UNDEFINED_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED);
+	zend_string *const_UNDEFINED_name = zend_string_init_interned("UNDEFINED", sizeof("UNDEFINED") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_UNDEFINED_name, &const_UNDEFINED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_UNDEFINED_name, true);
+
+	zval const_FLOAT16_value;
+	ZVAL_LONG(&const_FLOAT16_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+	zend_string *const_FLOAT16_name = zend_string_init_interned("FLOAT16", sizeof("FLOAT16") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_FLOAT16_name, &const_FLOAT16_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_FLOAT16_name, true);
+
+	zval const_FLOAT32_value;
+	ZVAL_LONG(&const_FLOAT32_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT32);
+	zend_string *const_FLOAT32_name = zend_string_init_interned("FLOAT32", sizeof("FLOAT32") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_FLOAT32_name, &const_FLOAT32_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_FLOAT32_name, true);
+
+	zval const_FLOAT64_value;
+	ZVAL_LONG(&const_FLOAT64_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT64);
+	zend_string *const_FLOAT64_name = zend_string_init_interned("FLOAT64", sizeof("FLOAT64") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_FLOAT64_name, &const_FLOAT64_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_FLOAT64_name, true);
+
+	zval const_UINT8_value;
+	ZVAL_LONG(&const_UINT8_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+	zend_string *const_UINT8_name = zend_string_init_interned("UINT8", sizeof("UINT8") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_UINT8_name, &const_UINT8_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_UINT8_name, true);
+
+	zval const_INT8_value;
+	ZVAL_LONG(&const_INT8_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8);
+	zend_string *const_INT8_name = zend_string_init_interned("INT8", sizeof("INT8") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_INT8_name, &const_INT8_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_INT8_name, true);
+
+	zval const_UINT16_value;
+	ZVAL_LONG(&const_UINT16_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16);
+	zend_string *const_UINT16_name = zend_string_init_interned("UINT16", sizeof("UINT16") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_UINT16_name, &const_UINT16_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_UINT16_name, true);
+
+	zval const_INT16_value;
+	ZVAL_LONG(&const_INT16_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16);
+	zend_string *const_INT16_name = zend_string_init_interned("INT16", sizeof("INT16") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_INT16_name, &const_INT16_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_INT16_name, true);
+
+	zval const_UINT32_value;
+	ZVAL_LONG(&const_UINT32_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32);
+	zend_string *const_UINT32_name = zend_string_init_interned("UINT32", sizeof("UINT32") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_UINT32_name, &const_UINT32_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_UINT32_name, true);
+
+	zval const_INT32_value;
+	ZVAL_LONG(&const_INT32_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32);
+	zend_string *const_INT32_name = zend_string_init_interned("INT32", sizeof("INT32") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_INT32_name, &const_INT32_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_INT32_name, true);
+
+	zval const_INT64_value;
+	ZVAL_LONG(&const_INT64_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+	zend_string *const_INT64_name = zend_string_init_interned("INT64", sizeof("INT64") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_INT64_name, &const_INT64_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_INT64_name, true);
+
+	zval const_BOOL_value;
+	ZVAL_LONG(&const_BOOL_value, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+	zend_string *const_BOOL_name = zend_string_init_interned("BOOL", sizeof("BOOL") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_BOOL_name, &const_BOOL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_BOOL_name, true);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Model(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT", "Model", class_ORT_Model_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#if (PHP_VERSION_ID >= 80100)
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#elif (PHP_VERSION_ID >= 80000)
+	class_entry->ce_flags |= 0;
+#endif
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Runtime(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT", "Runtime", class_ORT_Runtime_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#if (PHP_VERSION_ID >= 80100)
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#elif (PHP_VERSION_ID >= 80000)
+	class_entry->ce_flags |= 0;
+#endif
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Options(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT", "Options", class_ORT_Options_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#if (PHP_VERSION_ID >= 80100)
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#elif (PHP_VERSION_ID >= 80000)
+	class_entry->ce_flags |= 0;
+#endif
+#endif
+
+	zval const_LVERBOSE_value;
+	ZVAL_LONG(&const_LVERBOSE_value, ORT_LOGGING_LEVEL_VERBOSE);
+	zend_string *const_LVERBOSE_name = zend_string_init_interned("LVERBOSE", sizeof("LVERBOSE") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_LVERBOSE_name, &const_LVERBOSE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_LVERBOSE_name, true);
+
+	zval const_LINFO_value;
+	ZVAL_LONG(&const_LINFO_value, ORT_LOGGING_LEVEL_INFO);
+	zend_string *const_LINFO_name = zend_string_init_interned("LINFO", sizeof("LINFO") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_LINFO_name, &const_LINFO_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_LINFO_name, true);
+
+	zval const_LWARNING_value;
+	ZVAL_LONG(&const_LWARNING_value, ORT_LOGGING_LEVEL_WARNING);
+	zend_string *const_LWARNING_name = zend_string_init_interned("LWARNING", sizeof("LWARNING") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_LWARNING_name, &const_LWARNING_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_LWARNING_name, true);
+
+	zval const_LERROR_value;
+	ZVAL_LONG(&const_LERROR_value, ORT_LOGGING_LEVEL_ERROR);
+	zend_string *const_LERROR_name = zend_string_init_interned("LERROR", sizeof("LERROR") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_LERROR_name, &const_LERROR_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_LERROR_name, true);
+
+	zval const_LFATAL_value;
+	ZVAL_LONG(&const_LFATAL_value, ORT_LOGGING_LEVEL_FATAL);
+	zend_string *const_LFATAL_name = zend_string_init_interned("LFATAL", sizeof("LFATAL") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_LFATAL_name, &const_LFATAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_LFATAL_name, true);
+
+	zval const_ESEQUENTIAL_value;
+	ZVAL_LONG(&const_ESEQUENTIAL_value, ORT_SEQUENTIAL);
+	zend_string *const_ESEQUENTIAL_name = zend_string_init_interned("ESEQUENTIAL", sizeof("ESEQUENTIAL") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_ESEQUENTIAL_name, &const_ESEQUENTIAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_ESEQUENTIAL_name, true);
+
+	zval const_EPARALLEL_value;
+	ZVAL_LONG(&const_EPARALLEL_value, ORT_PARALLEL);
+	zend_string *const_EPARALLEL_name = zend_string_init_interned("EPARALLEL", sizeof("EPARALLEL") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_EPARALLEL_name, &const_EPARALLEL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_EPARALLEL_name, true);
+
+	zval const_ONONE_value;
+	ZVAL_LONG(&const_ONONE_value, ORT_DISABLE_ALL);
+	zend_string *const_ONONE_name = zend_string_init_interned("ONONE", sizeof("ONONE") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_ONONE_name, &const_ONONE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_ONONE_name, true);
+
+	zval const_OBASIC_value;
+	ZVAL_LONG(&const_OBASIC_value, ORT_ENABLE_BASIC);
+	zend_string *const_OBASIC_name = zend_string_init_interned("OBASIC", sizeof("OBASIC") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_OBASIC_name, &const_OBASIC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_OBASIC_name, true);
+
+	zval const_OEXTENDED_value;
+	ZVAL_LONG(&const_OEXTENDED_value, ORT_ENABLE_EXTENDED);
+	zend_string *const_OEXTENDED_name = zend_string_init_interned("OEXTENDED", sizeof("OEXTENDED") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_OEXTENDED_name, &const_OEXTENDED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_OEXTENDED_name, true);
+
+	zval const_OALL_value;
+	ZVAL_LONG(&const_OALL_value, ORT_ENABLE_ALL);
+	zend_string *const_OALL_name = zend_string_init_interned("OALL", sizeof("OALL") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_OALL_name, &const_OALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_OALL_name, true);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Tensor_Persistent(zend_class_entry *class_entry_ORT_Tensor)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Tensor", "Persistent", class_ORT_Tensor_Persistent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#if (PHP_VERSION_ID >= 80100)
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#elif (PHP_VERSION_ID >= 80000)
+	class_entry->ce_flags |= 0;
+#endif
+#endif
+	zend_class_implements(class_entry, 1, class_entry_ORT_Tensor);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Tensor_Transient(zend_class_entry *class_entry_ORT_Tensor)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Tensor", "Transient", class_ORT_Tensor_Transient_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_NOT_SERIALIZABLE);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#if (PHP_VERSION_ID >= 80100)
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#elif (PHP_VERSION_ID >= 80000)
+	class_entry->ce_flags |= 0;
+#endif
+#endif
+	zend_class_implements(class_entry, 1, class_entry_ORT_Tensor);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Tensor_Generator(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Tensor", "Generator", class_ORT_Tensor_Generator_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_ABSTRACT);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_ABSTRACT;
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Tensor_Generator_Random(zend_class_entry *class_entry_ORT_Tensor_Generator)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Tensor\\Generator", "Random", class_ORT_Tensor_Generator_Random_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Tensor_Generator, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Tensor_Generator);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Model_Iterator(zend_class_entry *class_entry_Iterator)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Model", "Iterator", class_ORT_Model_Iterator_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#endif
+	zend_class_implements(class_entry, 1, class_entry_Iterator);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Math_Schema(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Math", "Schema", class_ORT_Math_Schema_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
+
+	zval const_BINARY_value;
+	ZVAL_LONG(&const_BINARY_value, ORT_MATH_PROMOTION_SCHEMA_KIND_BINARY);
+	zend_string *const_BINARY_name = zend_string_init_interned("BINARY", sizeof("BINARY") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_BINARY_name, &const_BINARY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_BINARY_name, true);
+
+	zval const_UNARY_value;
+	ZVAL_LONG(&const_UNARY_value, ORT_MATH_PROMOTION_SCHEMA_KIND_UNARY);
+	zend_string *const_UNARY_name = zend_string_init_interned("UNARY", sizeof("UNARY") - 1, true);
+	zend_declare_class_constant_ex(class_entry, const_UNARY_name, &const_UNARY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release_ex(const_UNARY_name, true);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Error(zend_class_entry *class_entry_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status", "Error", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_SafetyError(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status", "SafetyError", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_ScalingError(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status", "ScalingError", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_Error(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "Error", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_NotFound(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "NotFound", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidType(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidType", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidShape(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidShape", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidData(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidData", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidMemory(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidMemory", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidOffset(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidOffset", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Tensor_InvalidAccess(zend_class_entry *class_entry_ORT_Status_Tensor_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Tensor", "InvalidAccess", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Tensor_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Tensor_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_Error(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "Error", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_InvalidShape(zend_class_entry *class_entry_ORT_Status_Math_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "InvalidShape", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Math_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Math_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_InvalidType(zend_class_entry *class_entry_ORT_Status_Math_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "InvalidType", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Math_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Math_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_InvalidBroadcast(zend_class_entry *class_entry_ORT_Status_Math_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "InvalidBroadcast", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Math_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Math_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_InvalidOperation(zend_class_entry *class_entry_ORT_Status_Math_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "InvalidOperation", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Math_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Math_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Math_DivisionByZero(zend_class_entry *class_entry_ORT_Status_Math_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Math", "DivisionByZero", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Math_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Math_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_Error(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "Error", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidMemory(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidMemory", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidOptions(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidOptions", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidModel(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidModel", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidInput(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidInput", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidOutput(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidOutput", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidIndex(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidIndex", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_InvalidFile(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "InvalidFile", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Model_RuntimeException(zend_class_entry *class_entry_ORT_Status_Model_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Model", "RuntimeException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Model_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Model_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Schema_Error(zend_class_entry *class_entry_ORT_Status_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Schema", "Error", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Schema_InvalidSymbol(zend_class_entry *class_entry_ORT_Status_Schema_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Schema", "InvalidSymbol", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Schema_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Schema_Error);
+#endif
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ORT_Status_Schema_InvalidArguments(zend_class_entry *class_entry_ORT_Status_Schema_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ORT\\Status\\Schema", "InvalidArguments", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_ORT_Status_Schema_Error, 0);
+#else
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_ORT_Status_Schema_Error);
+#endif
+
+	return class_entry;
+}


### PR DESCRIPTION
This PR introduces `.stub.php` files as the source of truth for the extension's API definitions, using the same approach adopted by PHP core and many bundled extensions since PHP 8.0.

## Motivation and Context

While testing out ORT in a project, I noticed that IDEs couldn't provide autocompletion or type hints since the extension is written in C. This led me to explore contributing IDE stubs, but while examining the codebase, I discovered a deeper maintenance challenge (for me at least)

The extension currently maintains arginfo structures manually using C macros scattered throughout the source files. While there are convenience macros like `ORT_MATH_BINARY_FUNCTION_IMPL` and `ORT_MATH_REDUCTION_TENSOR_FUNCTION_IMPL` that help reduce boilerplate, they add complexity and make it difficult to see the actual PHP interface layer at a glance. This creates several problems:

1. **Documentation becomes difficult**: There's no single, clear place to see what the PHP API looks like. To understand the interface, you must manually peruse C files and decode macro expansions.

2. **Stub maintenance is error-prone**: If a separate IDE stubs package were to be maintained, it would require manually tracking changes across multiple C files, making it easy to miss new functions, methods, or signature changes.

3. **API visibility is poor**: When new functions or methods are added, it's hard to immediately see how they affect the PHP interface. The relationship between C implementation and PHP API is implicit rather than explicit.

4. **Maintenance overhead**: Every API change requires updating both the C arginfo macros and potentially separate documentation or stub files, increasing the chance of inconsistencies.

PHP core solved this elegantly by introducing `gen_stub.php`, which allows extension authors to define their API in familiar PHP syntax (`.stub.php` files) and automatically generate the C arginfo structures. This approach is now standard across PHP's bundled extensions and is [officially documented](https://php.github.io/php-src/miscellaneous/stubs.html) as the recommended way to maintain extension APIs.

**Important note**: This change only affects the PHP-facing API layer (arginfo generation). It does not touch the low-level maths implementation layer, which maintains its own strict naming conventions (as documented in `docs/naming.md`). The maths backend functions, macros, and internal structures remain completely unchanged.

The key insight is that writing PHP syntax is far more readable and maintainable than writing C macros like `ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX`. Compare:

```c
// Current approach (C macros)
ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_ort_tensor_getSlice_arginfo, 0, 2, ORT\\Tensor, 0)
    ZEND_ARG_TYPE_INFO(0, start, IS_ARRAY, 0)
    ZEND_ARG_TYPE_INFO(0, end, IS_ARRAY, 0)
    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, axis, IS_ARRAY, 0, "[]")
ZEND_END_ARG_INFO()
```

```php
// Stub approach (PHP syntax)
public function getSlice(array $start, array $end, array $axis = []): \ORT\Tensor {}
```

The generator handles all the complexity like PHP version compatibility, proper escaping, function entry tables, and even class registration boilerplate. As noted in the [PHP stubs documentation](https://php.github.io/php-src/miscellaneous/stubs.html), the generated arginfo files include a hash of the stub file, which ensures that regeneration only happens when the stub file actually changes, making the build process efficient.

## What's Included

| File | Description |
|------|-------------|
| `ort.stub.php` | Complete API definition for all classes, interfaces, functions, and constants |
| `ort_arginfo.h` | Generated C header (1600 lines) containing all arginfo, function entries, and class registration helpers |
| `gen_stub.php` | The generator script from [php-src](https://github.com/php/php-src/blob/master/build/gen_stub.php), adjusted to prefer Composer's PHP-Parser over downloading |
| `Makefile.frag` | Added `make ort-stubs` target |
| `composer.json` | Added `nikic/php-parser` as dev dependency |

The `gen_stub.php` script was downloaded from the [PHP source repository](https://github.com/php/php-src/blob/master/build/gen_stub.php) and modified to check for a local Composer autoloader first (via `vendor/autoload.php`) before attempting to download PHP-Parser. This ensures it works seamlessly with the project's existing Composer setup.

The stub file covers the entire public API:
- `ORT\Tensor` interface and constants (`FLOAT32`, `INT64`, etc.)
- `ORT\Tensor\Persistent` and `ORT\Tensor\Transient` classes
- `ORT\Model`, `ORT\Runtime`, `ORT\Options` classes
- All `ORT\Math` namespace functions (40+ math operations)
- Complete exception hierarchy (`ORT\Status\*`)

This approach is used extensively in PHP core. For example:
- **ext/dom**: [php_dom.stub.php](https://github.com/php/php-src/blob/master/ext/dom/php_dom.stub.php) → `php_dom_arginfo.h`
- **ext/pdo**: Multiple stub files including [pdo.stub.php](https://github.com/php/php-src/blob/master/ext/pdo/pdo.stub.php), [pdo_dbh.stub.php](https://github.com/php/php-src/blob/master/ext/pdo/pdo_dbh.stub.php), and [pdo_stmt.stub.php](https://github.com/php/php-src/blob/master/ext/pdo/pdo_stmt.stub.php), each generating their own arginfo files
- **ext/date**: [php_date.stub.php](https://github.com/php/php-src/blob/master/ext/date/php_date.stub.php) → `php_date_arginfo.h`
- **ext/random**: [random.stub.php](https://github.com/php/php-src/blob/master/ext/random/random.stub.php) → `random_arginfo.h`

Userland extensions also adopt this approach. For instance, **phpredis** maintains [redis.stub.php](https://github.com/phpredis/phpredis/blob/develop/redis.stub.php) in their repository, which serves as both the source for generating arginfo.

## Next Steps (Optional Integration)

**This PR is intentionally non-breaking**. It just adds files alongside the existing code without modifying any current functionality. The generated `ort_arginfo.h` is provided for reference and can be integrated gradually at your convenience.

If you'd like to integrate the generated arginfo, here's how it could work:

**1. Include the generated header in `src/tensor.c`:**

```c
#include "ort_arginfo.h"  // Add near top of file
```

**2. Replace manual arginfo definitions:**

The generated `ort_arginfo.h` provides identical arginfo under standardized names. You can remove the manual arginfo definitions and reference the generated ones instead.

For example, in `src/tensor.c` around line 669, you would remove:

```c
// Remove this entire block (lines ~669-675)
ZEND_BEGIN_ARG_INFO_EX(php_ort_tensor_persistent_construct_arginfo, 0, 0, 1)
    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
    ZEND_ARG_TYPE_INFO(0, shape, IS_ARRAY, 0)
    ZEND_ARG_TYPE_MASK(0, data, MAY_BE_ARRAY | MAY_BE_OBJECT, NULL)
    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
ZEND_END_ARG_INFO()
```

And add a simple `#define` near the top of the file (after `#include "ort_arginfo.h"`):

```c
// Add this after including ort_arginfo.h
#define php_ort_tensor_persistent_construct_arginfo arginfo_class_ORT_Tensor_Persistent___construct
#define php_ort_tensor_isPersistent_arginfo arginfo_class_ORT_Tensor_isPersistent
#define php_ort_tensor_getName_arginfo arginfo_class_ORT_Tensor_getName
// ... etc for all arginfo structures
```

This keeps the C files simpler and you no longer need to maintain arginfo definitions manually, as they're automatically generated from the stub file.

**3. Replace function entry arrays:**

The generated header also includes complete function entry arrays. For example, in `src/tensor.c` around lines 1806-1820, you could replace:

```c
// Current (lines ~1806-1820)
zend_function_entry php_ort_tensor_persistent_methods[] = {
    PHP_ME(ONNX_Tensor_Persistent, __construct,
        php_ort_tensor_persistent_construct_arginfo, ZEND_ACC_PUBLIC)
    PHP_ME(ONNX_Tensor, isPersistent, php_ort_tensor_isPersistent_arginfo, ZEND_ACC_PUBLIC)
    // ... rest of entries
    PHP_FE_END
};
```

With a reference to the generated array:

```c
// Use generated function entry array
#define php_ort_tensor_persistent_methods class_ORT_Tensor_Persistent_methods
```

The generated array (see `ort_arginfo.h` lines 814-827) is identical but uses standardized naming conventions.

**4. Optionally use generated class registration:**

The generated header includes helper functions like `register_class_ORT_Tensor_Persistent()`. These handle interface implementation, flags, and constants automatically. In `PHP_MINIT(ORT_TENSOR)`, you could use:

```c
// Current approach (works fine, no change needed)
INIT_NS_CLASS_ENTRY(ce, "ORT\\Tensor", "Persistent", php_ort_tensor_persistent_methods);
php_ort_tensor_persistent_ce = zend_register_internal_class(&ce);
php_ort_tensor_persistent_ce->create_object = php_ort_tensor_create;
zend_class_implements(php_ort_tensor_persistent_ce, 1, php_ort_tensor_interface_ce);

// Alternative using generated helper
php_ort_tensor_persistent_ce = register_class_ORT_Tensor_Persistent(php_ort_tensor_interface_ce);
php_ort_tensor_persistent_ce->create_object = php_ort_tensor_create;
```

The generated functions handle PHP version compatibility automatically (e.g., `ZEND_ACC_NOT_SERIALIZABLE` flags for PHP 8.1+).

**Integration Offer:** If this PR is accepted, I'm happy to help with the integration work either by doing it myself in a follow-up PR, or by providing guidance as you integrate it. The goal is to make this transition as smooth as possible.

## IDE Stubs Distribution

Since ORT is a C extension, the stub file won't reach end users, only the compiled `.so` is loaded. To provide IDE support, you might consider publishing a separate `krakjoe/ort-stubs` package on Packagist. Users would then:

```bash
composer require --dev krakjoe/ort-stubs
```

The `ort.stub.php` file (with `@generate-*` annotations removed) would serve as the basis for such a package. 

---

I understand this represents a shift in how the extension is maintained, and I wanted to share an approach that's might maintaining and contributions from others significantly easier. If you have questions or would like any adjustments, I'm happy to discuss. If this doesn't fit your workflow, no worries at all, **feel free to close this PR**.
